### PR TITLE
Add numerical optimizer options for acqusition optimization.

### DIFF
--- a/lcls_ii/emittance/bax/bax-emittance-minimization-LCLSII.ipynb
+++ b/lcls_ii/emittance/bax/bax-emittance-minimization-LCLSII.ipynb
@@ -79,8 +79,8 @@
     "N_ITER = 25 # number of iterations for Xopt to perform\n",
     "\n",
     "# BAX algorithm settings\n",
-    "N_SAMPLES = 20\n",
-    "N_STEPS_MEASUREMENT_PARAM = 10\n",
+    "N_SAMPLES = 10\n",
+    "N_STEPS_MEASUREMENT_PARAM = 3\n",
     "N_STEPS_EXE_PATHS = 10\n",
     "\n",
     "# measurement settings\n",
@@ -326,6 +326,28 @@
   },
   {
    "cell_type": "markdown",
+   "id": "331cc0fc",
+   "metadata": {},
+   "source": [
+    "# Numerical optimizer (for acquisition function)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "b8c78246",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from xopt.numerical_optimizer import LBFGSOptimizer\n",
+    "numerical_optimizer = LBFGSOptimizer(\n",
+    "                                    n_raw_samples=20,\n",
+    "                                    n_restarts=20,\n",
+    "                                    max_iter=100)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
    "id": "bd586df8",
    "metadata": {},
    "source": [
@@ -343,17 +365,19 @@
      "evalue": "name 'vocs' is not defined",
      "output_type": "error",
      "traceback": [
-      "\u001B[1;31m---------------------------------------------------------------------------\u001B[0m",
-      "\u001B[1;31mNameError\u001B[0m                                 Traceback (most recent call last)",
-      "Cell \u001B[1;32mIn[4], line 2\u001B[0m\n\u001B[0;32m      1\u001B[0m \u001B[38;5;66;03m#construct BAX generator\u001B[39;00m\n\u001B[1;32m----> 2\u001B[0m generator \u001B[38;5;241m=\u001B[39m BaxGenerator(vocs\u001B[38;5;241m=\u001B[39m\u001B[43mvocs\u001B[49m, model_constructor\u001B[38;5;241m=\u001B[39mmodel_constructor, algorithm\u001B[38;5;241m=\u001B[39malgo)\n\u001B[0;32m      4\u001B[0m \u001B[38;5;66;03m#construct evaluator\u001B[39;00m\n\u001B[0;32m      5\u001B[0m evaluator \u001B[38;5;241m=\u001B[39m Evaluator(function\u001B[38;5;241m=\u001B[39meval_beamsize)\n",
-      "\u001B[1;31mNameError\u001B[0m: name 'vocs' is not defined"
+      "\u001b[1;31m---------------------------------------------------------------------------\u001b[0m",
+      "\u001b[1;31mNameError\u001b[0m                                 Traceback (most recent call last)",
+      "Cell \u001b[1;32mIn[4], line 2\u001b[0m\n\u001b[0;32m      1\u001b[0m \u001b[38;5;66;03m#construct BAX generator\u001b[39;00m\n\u001b[1;32m----> 2\u001b[0m generator \u001b[38;5;241m=\u001b[39m BaxGenerator(vocs\u001b[38;5;241m=\u001b[39m\u001b[43mvocs\u001b[49m, model_constructor\u001b[38;5;241m=\u001b[39mmodel_constructor, algorithm\u001b[38;5;241m=\u001b[39malgo)\n\u001b[0;32m      4\u001b[0m \u001b[38;5;66;03m#construct evaluator\u001b[39;00m\n\u001b[0;32m      5\u001b[0m evaluator \u001b[38;5;241m=\u001b[39m Evaluator(function\u001b[38;5;241m=\u001b[39meval_beamsize)\n",
+      "\u001b[1;31mNameError\u001b[0m: name 'vocs' is not defined"
      ]
     }
    ],
    "source": [
     "#construct BAX generator\n",
-    "generator = BaxGenerator(vocs=vocs, model_constructor=model_constructor, algorithm=algo)\n",
-    "\n",
+    "generator = BaxGenerator(vocs=vocs, \n",
+    "                         model_constructor=model_constructor, \n",
+    "                         numerical_optimizer=numerical_optimizer,\n",
+    "                         algorithm=algo)\n",
     "#construct evaluator\n",
     "evaluator = Evaluator(function=eval_beamsize)\n",
     "\n",


### PR DESCRIPTION
Add cell with options for numerical optimization (maxiter=100) of the acquisition function. Also reduce the amount of samples used by BAX in Expected Information Gain from 20 to 10. Both changes improve BaxGenerator compute time.