### PR TITLE
Add exemplary calibration notebook

### DIFF
--- a/lcls/nn_prior/calibration/calibration_example.ipynb
+++ b/lcls/nn_prior/calibration/calibration_example.ipynb
@@ -1,0 +1,1162 @@
+{
+ "cells": [
+  {
+   "cell_type": "code",
+   "execution_count": 1,
+   "metadata": {
+    "ExecuteTime": {
+     "end_time": "2023-04-26T12:20:23.809750Z",
+     "start_time": "2023-04-26T12:20:21.653781Z"
+    }
+   },
+   "outputs": [],
+   "source": [
+    "import sys\n",
+    "import warnings\n",
+    "warnings.filterwarnings(\"ignore\")\n",
+    "\n",
+    "import torch\n",
+    "import numpy as np\n",
+    "import pandas as pd\n",
+    "import matplotlib.pyplot as plt\n",
+    "\n",
+    "# fix random seeds\n",
+    "rng_seed = 0\n",
+    "torch.manual_seed(rng_seed)\n",
+    "np.random.seed(rng_seed)\n",
+    "\n",
+    "from xopt import Xopt, VOCS\n",
+    "from xopt.evaluator import Evaluator\n",
+    "from xopt.numerical_optimizer import LBFGSOptimizer\n",
+    "from xopt.generators.bayesian import ExpectedImprovementGenerator\n",
+    "from xopt.generators.bayesian.models.standard import StandardModelConstructor\n",
+    "from lume_model.models import TorchModule\n",
+    "\n",
+    "sys.path.append(\"../\")\n",
+    "sys.path.append(\"calibration_modules/\")\n",
+    "import utils\n",
+    "from calibration_modules.decoupled_linear import DecoupledLinear"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 2,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "cpu\n"
+     ]
+    }
+   ],
+   "source": [
+    "device = \"cuda\" if torch.cuda.is_available() else \"cpu\"\n",
+    "print(device)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Definition of Objective"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 3,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# create Xopt vocs\n",
+    "vocs = VOCS.from_yaml(\n",
+    "    \"\"\"\n",
+    "    variables:\n",
+    "      distgen:r_dist:sigma_xy:value: [0.21021247820852546, 0.4999996083265339]\n",
+    "      distgen:t_dist:length:value: [3.000000758511308, 11.998569812014836]\n",
+    "      SOL1:solenoid_field_scale: [0.19409053333889578, 0.2563030896232562]\n",
+    "      CQ01:b1_gradient: [-0.009999618141995313, 0.0099925212795954]\n",
+    "      SQ01:b1_gradient: [-0.009999490058927914, 0.009999443099573097]\n",
+    "      L0A_phase:dtheta0_deg: [-24.998714513984325, 9.991752397382681]\n",
+    "      L0B_phase:dtheta0_deg: [-24.99972566363747, 9.998904767155892]\n",
+    "      QA01:b1_gradient: [1.000039854940649, 3.998197816908352]\n",
+    "      QA02:b1_gradient: [-3.990444304119449, -1.0105116218007806]\n",
+    "      QE01:b1_gradient: [1.0007061999094193, 6.9997773994714345]\n",
+    "      QE02:b1_gradient: [-6.999887318319171, 0.9983521010385275]\n",
+    "      QE03:b1_gradient: [-6.998418428856965, 0.9993010487139868]\n",
+    "      QE04:b1_gradient: [1.000026533968218, 6.998086093251312]\n",
+    "    constraints: {}\n",
+    "    objectives: {sigma_xy: MINIMIZE}\n",
+    "    constants: {'distgen:total_charge:value': 250.0, 'L0A_scale:voltage': 58000000.0,\n",
+    "      'L0B_scale:voltage': 70000000.0}\n",
+    "    observables: []\n",
+    "    \"\"\"\n",
+    ")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 4,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# create objective model\n",
+    "objective_model = utils.load_model(\n",
+    "    input_variables=vocs.variable_names,\n",
+    "    model_path=\"../lcls_cu_injector_nn_model/\",\n",
+    "    use_sim_model=True,\n",
+    ")\n",
+    "lume_model = objective_model.model.model\n",
+    "lume_module = objective_model.model"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 5,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# define miscalibrated objective model\n",
+    "mismatch_scale = 0.3\n",
+    "x_size = len(lume_module.input_order)\n",
+    "y_size = len(vocs.objective_names)\n",
+    "\n",
+    "miscalibrated_objective_model = DecoupledLinear(\n",
+    "    model=objective_model,\n",
+    "    x_size=x_size,\n",
+    "    y_size=y_size,\n",
+    "    x_offset_initial=mismatch_scale * torch.rand(x_size),\n",
+    "    x_scale_initial=torch.ones(x_size) + mismatch_scale * torch.rand(x_size),\n",
+    "    y_offset_initial=mismatch_scale * torch.rand(y_size),\n",
+    "    y_scale_initial=torch.ones(y_size) + mismatch_scale * torch.rand(y_size),\n",
+    ")\n",
+    "miscalibrated_objective_model.requires_grad_(False);"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Bayesian Approach"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Define Custom Mean and Xopt Config"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 6,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# define custom mean\n",
+    "custom_mean = DecoupledLinear(\n",
+    "    model=miscalibrated_objective_model,\n",
+    "    x_size=x_size,\n",
+    "    y_size=y_size,\n",
+    ")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 7,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "def evaluate(input_dict, generator, lume_model, objective_model, noise_level = 0.0):\n",
+    "    model_result = lume_model.evaluate(input_dict)\n",
+    "    sigma_xy = objective_model.function(model_result[\"sigma_x\"], model_result[\"sigma_y\"])\n",
+    "    noise = noise_level * torch.rand(sigma_xy.shape)\n",
+    "    total_size = sigma_xy + noise\n",
+    "    output_dict = {generator.vocs.objective_names[0]: total_size.detach().item()}\n",
+    "    return output_dict"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 8,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Xopt definition\n",
+    "gp_constructor = StandardModelConstructor(\n",
+    "    use_low_noise_prior=True,\n",
+    "    mean_modules={vocs.objective_names[0]: custom_mean},\n",
+    "    trainable_mean_keys=[vocs.objective_names[0]],\n",
+    ")\n",
+    "numerical_optimizer = LBFGSOptimizer(n_restarts=5, max_iter=20)\n",
+    "generator = ExpectedImprovementGenerator(\n",
+    "    vocs=vocs,\n",
+    "    gp_constructor=gp_constructor,\n",
+    "    numerical_optimizer=numerical_optimizer,\n",
+    ")\n",
+    "evaluator = Evaluator(function=evaluate)\n",
+    "X = Xopt(generator=generator, evaluator=evaluator, vocs=vocs)\n",
+    "evaluate_kwargs = {\n",
+    "    \"generator\": X.generator,\n",
+    "    \"lume_model\": lume_model,\n",
+    "    \"objective_model\": objective_model,\n",
+    "    \"noise_level\": 0.0,\n",
+    "}\n",
+    "X.evaluator = Evaluator(function=evaluate, function_kwargs=evaluate_kwargs)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 9,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/html": [
+       "<div>\n",
+       "<style scoped>\n",
+       "    .dataframe tbody tr th:only-of-type {\n",
+       "        vertical-align: middle;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe tbody tr th {\n",
+       "        vertical-align: top;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe thead th {\n",
+       "        text-align: right;\n",
+       "    }\n",
+       "</style>\n",
+       "<table border=\"1\" class=\"dataframe\">\n",
+       "  <thead>\n",
+       "    <tr style=\"text-align: right;\">\n",
+       "      <th></th>\n",
+       "      <th>distgen:r_dist:sigma_xy:value</th>\n",
+       "      <th>distgen:t_dist:length:value</th>\n",
+       "      <th>SOL1:solenoid_field_scale</th>\n",
+       "      <th>CQ01:b1_gradient</th>\n",
+       "      <th>SQ01:b1_gradient</th>\n",
+       "      <th>L0A_phase:dtheta0_deg</th>\n",
+       "      <th>L0B_phase:dtheta0_deg</th>\n",
+       "      <th>QA01:b1_gradient</th>\n",
+       "      <th>QA02:b1_gradient</th>\n",
+       "      <th>QE01:b1_gradient</th>\n",
+       "      <th>QE02:b1_gradient</th>\n",
+       "      <th>QE03:b1_gradient</th>\n",
+       "      <th>QE04:b1_gradient</th>\n",
+       "      <th>distgen:total_charge:value</th>\n",
+       "      <th>L0A_scale:voltage</th>\n",
+       "      <th>L0B_scale:voltage</th>\n",
+       "      <th>sigma_xy</th>\n",
+       "      <th>xopt_runtime</th>\n",
+       "      <th>xopt_error</th>\n",
+       "    </tr>\n",
+       "  </thead>\n",
+       "  <tbody>\n",
+       "    <tr>\n",
+       "      <th>0</th>\n",
+       "      <td>0.340961</td>\n",
+       "      <td>7.095401</td>\n",
+       "      <td>0.229080</td>\n",
+       "      <td>0.002327</td>\n",
+       "      <td>-0.001361</td>\n",
+       "      <td>6.943058</td>\n",
+       "      <td>-17.235516</td>\n",
+       "      <td>1.602194</td>\n",
+       "      <td>-1.362961</td>\n",
+       "      <td>1.332641</td>\n",
+       "      <td>-1.117627</td>\n",
+       "      <td>-3.546874</td>\n",
+       "      <td>3.326699</td>\n",
+       "      <td>250.0</td>\n",
+       "      <td>58000000.0</td>\n",
+       "      <td>70000000.0</td>\n",
+       "      <td>1.762248</td>\n",
+       "      <td>0.001127</td>\n",
+       "      <td>False</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>1</th>\n",
+       "      <td>0.292747</td>\n",
+       "      <td>8.186283</td>\n",
+       "      <td>0.200824</td>\n",
+       "      <td>-0.005836</td>\n",
+       "      <td>-0.008512</td>\n",
+       "      <td>9.284301</td>\n",
+       "      <td>-20.450329</td>\n",
+       "      <td>2.614610</td>\n",
+       "      <td>-2.917433</td>\n",
+       "      <td>3.869172</td>\n",
+       "      <td>-5.194154</td>\n",
+       "      <td>0.849025</td>\n",
+       "      <td>3.297679</td>\n",
+       "      <td>250.0</td>\n",
+       "      <td>58000000.0</td>\n",
+       "      <td>70000000.0</td>\n",
+       "      <td>1.962777</td>\n",
+       "      <td>0.000415</td>\n",
+       "      <td>False</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>2</th>\n",
+       "      <td>0.325327</td>\n",
+       "      <td>6.186447</td>\n",
+       "      <td>0.196351</td>\n",
+       "      <td>-0.000581</td>\n",
+       "      <td>0.008579</td>\n",
+       "      <td>-19.142005</td>\n",
+       "      <td>-24.251397</td>\n",
+       "      <td>1.658048</td>\n",
+       "      <td>-1.437695</td>\n",
+       "      <td>4.512191</td>\n",
+       "      <td>-2.650047</td>\n",
+       "      <td>-3.940374</td>\n",
+       "      <td>1.337429</td>\n",
+       "      <td>250.0</td>\n",
+       "      <td>58000000.0</td>\n",
+       "      <td>70000000.0</td>\n",
+       "      <td>3.726567</td>\n",
+       "      <td>0.000336</td>\n",
+       "      <td>False</td>\n",
+       "    </tr>\n",
+       "  </tbody>\n",
+       "</table>\n",
+       "</div>"
+      ],
+      "text/plain": [
+       "   distgen:r_dist:sigma_xy:value  distgen:t_dist:length:value  \\\n",
+       "0                       0.340961                     7.095401   \n",
+       "1                       0.292747                     8.186283   \n",
+       "2                       0.325327                     6.186447   \n",
+       "\n",
+       "   SOL1:solenoid_field_scale  CQ01:b1_gradient  SQ01:b1_gradient  \\\n",
+       "0                   0.229080          0.002327         -0.001361   \n",
+       "1                   0.200824         -0.005836         -0.008512   \n",
+       "2                   0.196351         -0.000581          0.008579   \n",
+       "\n",
+       "   L0A_phase:dtheta0_deg  L0B_phase:dtheta0_deg  QA01:b1_gradient  \\\n",
+       "0               6.943058             -17.235516          1.602194   \n",
+       "1               9.284301             -20.450329          2.614610   \n",
+       "2             -19.142005             -24.251397          1.658048   \n",
+       "\n",
+       "   QA02:b1_gradient  QE01:b1_gradient  QE02:b1_gradient  QE03:b1_gradient  \\\n",
+       "0         -1.362961          1.332641         -1.117627         -3.546874   \n",
+       "1         -2.917433          3.869172         -5.194154          0.849025   \n",
+       "2         -1.437695          4.512191         -2.650047         -3.940374   \n",
+       "\n",
+       "   QE04:b1_gradient  distgen:total_charge:value  L0A_scale:voltage  \\\n",
+       "0          3.326699                       250.0         58000000.0   \n",
+       "1          3.297679                       250.0         58000000.0   \n",
+       "2          1.337429                       250.0         58000000.0   \n",
+       "\n",
+       "   L0B_scale:voltage  sigma_xy  xopt_runtime  xopt_error  \n",
+       "0         70000000.0  1.762248      0.001127       False  \n",
+       "1         70000000.0  1.962777      0.000415       False  \n",
+       "2         70000000.0  3.726567      0.000336       False  "
+      ]
+     },
+     "execution_count": 9,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "# create initial samples\n",
+    "n_init = 3\n",
+    "X.random_evaluate(n_samples=n_init)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Bayesian Optimization"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 10,
+   "metadata": {
+    "ExecuteTime": {
+     "end_time": "2023-04-26T12:20:24.520473Z",
+     "start_time": "2023-04-26T12:20:23.858800Z"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "CPU times: user 23min 57s, sys: 3min 38s, total: 27min 36s\n",
+      "Wall time: 16min 21s\n"
+     ]
+    }
+   ],
+   "source": [
+    "%%time\n",
+    "n_step = 100\n",
+    "for _ in range(n_step):\n",
+    "    X.step()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 11,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "image/png": "iVBORw0KGgoAAAANSUhEUgAAAnYAAAHWCAYAAAD6oMSKAAAAOXRFWHRTb2Z0d2FyZQBNYXRwbG90bGliIHZlcnNpb24zLjkuMiwgaHR0cHM6Ly9tYXRwbG90bGliLm9yZy8hTgPZAAAACXBIWXMAAA9hAAAPYQGoP6dpAABvkUlEQVR4nO3deXxU1R338e8syYQlRBEB2cGNTZDFCiqgtWCppSItrghW8ZFWRaV9VGqr4JY8tAZcAJdEUbAIUYiobDEaMAgaA0QFI0JAQgimQUkCSe425/kjZCQQYCbMzfzm8n2/Xnm9rsNkco4f0x7umXvHpZRSICIiIqKo5470AIiIiIgoPLiwIyIiInIILuyIiIiIHIILOyIiIiKH4MKOiIiIyCG4sCMiIiJyCC7siIiIiByCCzsiIiIih/BGegCR4Pf7sXfvXsTHx8PlckV6OERERETHpZRCRUUF2rVrB7f7xOfkTsuF3d69e9GxY8dID4OIiIgoaIWFhejQocMJn3NaLuzi4+MB1PwLatGihS0/w+/3Y//+/TjrrLNOurqmxsEmMrGLTOwiD5vI1BhdysvL0bFjx8D65URcp+NnxZaXlyMhIQFlZWW2LeyIiIiIwiGUdQuX/DbRNA3Tp0+HpmmRHgodxiYysYtM7CIPm8gkrQvP2Nl0xq72jY68QEMONpGJXWRiF3nYRKbG6BI1Z+zWrl2LUaNGoV27dnC5XEhPTz/p97z11lvo27cvmjZtinPOOQd//vOfsX//fvsH2wA+ny/SQ6CjsIlM7CITu8jDJjJJ6hLRhd2hQ4fQt29fvPjii0E9Pzs7G+PHj8edd96JLVu2IC0tDTk5OZg4caLNIw2drutISkqCruuRHgodxiYysYtM7CIPm8gkrYuYrViXy4WlS5di9OjRx33Of/7zH8ydOxc7duwIPPbCCy9gxowZKCwsDPpnNdZWrK7riI2N5SlzIdhEJnaRiV3kYROZGqNL1GzFhuqyyy7Dnj17sHz5ciil8OOPP+Kdd97BtddeG+mh1UvKGynpF2wiE7vIxC7ysIlMkrpE3cLurbfewo033ojY2Fi0bdsWZ5xxBl544YUTfp+maSgvL6/zBQCGYQAATNOEaZqBx+o71nUdlmXVe+z3+wM/p/a4oqICM2fOhK7r0DQNSikopY45BmrugXO849pTu5Zl1Xtsmmadedg5p6OPo21O1dXVmDlzJioqKhwzJyd0OnjwYOB3xSlzckInXdcxc+ZMVFVVOWZO0d7p0KFDgd8Vp8zJCZ1qf1cqKyttnVOwompht3XrVkyePBmPPfYYcnNzsXLlSuzcuROTJk064fclJiYiISEh8FX7qRMZGRkAgMzMTGRmZgIAVqxYgezsbABAeno6cnJyAACLFy9GXl4eAGD+/PnIz88HAKSkpKCgoAAAMHv2bBQVFQWO//KXv8Dn8yEpKQkVFRV19uErKiqQlJQEACgtLUVycjIAoKioCLNnzwYAFBQUICUlBQCQn5+P+fPnAwDy8vKwePFiAEBOTk7gopPs7GysWLHCtjklJyejtLQUAKJyTkVFRXj88ccDx06YkxM6LV68GH/605/g8/kcMycndPL5fDj33HMD83DCnKK908cff4xhw4bB5/M5Zk5O6OTz+TBo0KDAPOyYU+14g6KEAKCWLl16wueMGzdO/elPf6rz2KeffqoAqL179x73+6qrq1VZWVngq7CwUAFQpaWlSimlDMNQhmEopZTSdb3eY03TlGma9R5blhX4ObXHlZWVqri4WFmWpaqrq5Xf71d+v/+YY6VU4Dn1HWuappRSyjTNeo8Nw1C6rtd7HO45HX0cbXMyDEP9+OOPqrKy0jFzckKnqqoqtXfv3sDPdMKcnNDJsiy1Z8+ewPOdMKdo71RdXR34XXHKnJzQybIsVVRUFHiOHXMqKSlRAFRZWZk6maha2I0ZM0bdcMMNdR777LPPFABVVFQU9M8qKysL+l9QQ1VXV6tnnnkm8B8MRR6byMQuMrGLPGwiU2N0CWXdEtGrYg8ePIjt27cDAPr164fk5GRcddVVaNmyJTp16oSpU6eiqKgIb775JgBg3rx5uOuuu/D888/jmmuuQXFxMR544AG43W58/vnnQf9cfqQYERERRYuouSr2yy+/RL9+/dCvXz8AwJQpU9CvXz889thjAIDi4mLs3r078Pzbb78dycnJePHFF9G7d2+MHTsWF154IZYsWRKR8Z+I3+9HYWFh4I2PFHlsIhO7yMQu8rCJTNK6RHRhd+WVVwauVjnya968eQBqztBlZWXV+Z777rsPW7ZsQWVlJfbu3YsFCxagffv2jT/4kzAMA2lpaYGrZyjy2EQmdpGJXeRhE5mkdRFzg+LGxK1YIiIiihahrFu8jTSm00pZpYHnMrehrKwMCQkJYbsTdbszmuDPl3WB2807jjeE3+9HQUEBunXrBrc7qu7042jsIhO7yMMmMknrwoWdDQ7pJl5bt+vwP/0c1tfu3a4FLu12Vlhf83RhmiZWr16NiRMnIjY2NtLDocPYRSZ2kYdNZJLWhVuxNmzFllUZeGnNjpM/MQTvbSrC3rJqzL21P0ZedE5YX5uIiIjk4lZshCU0icHfh5+P/Px8dO/eHR6P55Rfc+vecuwtq8Yh3QrDCE9PlmWFtQmFB7vIxC7ysIlM0rpEfjPYoSzLwoYNGwKfBXeqmvlq/mOp1M2wvN7pKNxNKDzYRSZ2kYdNZJLWhVuxUXJV7N8W5+HdjXvwyMjumDTs3EgPh4iIiBpJ1Nyg2Mksy8LGjRvDf8ZO4xm7hgp3EwoPdpGJXeRhE5mkdeHCziaWZWHr1q1hC900tubtkHyPXcOFuwmFB7vIxC7ysIlM0rpwKzZKtmJfyPwez2Zsw82/6ojEMX0iPRwiIiJqJNyKFcA0Taxfvx6mGZ6t0yaxtRdPyPgbQTQKdxMKD3aRiV3kYROZpHXhws4mSins2bMH4Toh2sx3eCtW48KuocLdhMKDXWRiF3nYRCZpXbgVGyVbse9tLsL9b2/GZeeehf/eNSjSwyEiIqJGwq1YAUzTRFZWVthOzTbjxROnLNxNKDzYRSZ2kYdNZJLWhQs7myilUF5eHrZTs015u5NTFu4mFB7sIhO7yMMmMknrwq3YKNmK3Vx4AKNnr0P7M5pg3SO/jvRwiIiIqJFwK1YA0zSxatWqMG7F8iPFTlW4m1B4sItM7CIPm8gkrQsXdlGiqY/vsSMiIqIT41ZslGzFHqjUcfETGQCA7U+PhNfDNTkREdHpgFuxAhiGgWXLlsEwjLC8Xu0NigGg0uBZu4YIdxMKD3aRiV3kYROZpHXhws4mLpcLLVq0gMvlCsvrxXrc8LprXquSNylukHA3ofBgF5nYRR42kUlaF27FRslWLAD0mbYK5dUmMv82DOee3TzSwyEiIqJGwK1YAQzDQFpaWlhPzdZ+rBjP2DWMHU3o1LGLTOwiD5vIJK0LF3Y2cblc6NChQ1hPzTbhLU9OiR1N6NSxi0zsIg+byCStC7dio2grdtQL2fi6qAyv334JrureOtLDISIiokbArVgBdF3HggULoOt62F6z6eEzdod4xq5B7GhCp45dZGIXedhEJmlduLCzicfjQc+ePeHxeE7+5CDxPXanxo4mdOrYRSZ2kYdNZJLWxRvpATiVx+NB//79w/qafI/dqbGjCZ06dpGJXeRhE5mkdeEZO5vouo7U1NSwnpptFtiK5Rm7hrCjCZ06dpGJXeRhE5mkdeHCziYejweDBg0K66nZprGHt2J5xq5B7GhCp45dZGIXedhEJmlduBVrE4/Hg169eoX1NZv5Dp+x43vsGsSOJnTq2EUmdpGHTWSS1oVn7Gyi6zrmzJkT5qtiecbuVNjRhE4du8jELvKwiUzSunBhZxOv14sRI0bA6w3fSdGmgYsneMauIexoQqeOXWRiF3nYRCZpXWSMwoHcbjfOO++8sL5ms8AZOy7sGsKOJnTq2EUmdpGHTWSS1oVn7GyiaRqSk5OhaVrYXrNp4D123IptCDua0KljF5nYRR42kUlaFy7sbBITE4OxY8ciJiYmbK/JM3anxo4mdOrYRSZ2kYdNZJLWJaILu7Vr12LUqFFo164dXC4X0tPTT/o9mqbh0UcfRefOneHz+XDuuefitddes3+wIXK73ejYsSPc7vD9K+YNik+NHU3o1LGLTOwiD5vIJK1LREdx6NAh9O3bFy+++GLQ33PDDTcgMzMTqamp+O6777Bw4UJ0797dxlE2jKZpSExMDOupWZ6xOzV2NKFTxy4ysYs8bCKTtC4upZSK9CAAwOVyYenSpRg9evRxn7Ny5UrcdNNNKCgoQMuWLRv8s8rLy5GQkICysjK0aNGiwa9zIn6/H6WlpWjVqlXYVvE7/ncQVz+7Bi3ivPhq2jVhec3TiR1N6NSxi0zsIg+byNQYXUJZt0TVfxnLli3DwIEDMWPGDLRv3x4XXHAB/v73v6OqquqE36dpGsrLy+t8AYBhGAAA0zRhmmbgsfqOdV2HZVn1Hvv9/sDPqT02DCMQWdM0KKWglDrmGKj5j+J4x7X3xbEsCzGumteu1K3A46Zp1pmHnXM6+jgcc6rv2K45AUDr1q1hGIZj5uSETqZp4qyzzoLb7XbMnJzQye1244wzzkDt3/2dMKdo72RZFlq2bAm32+2YOTmhk9vtRsuWLev8/78dcwpWVC3sCgoKkJ2djW+++QZLly7FrFmz8M477+Cee+454fclJiYiISEh8NWxY0cAQEZGBgAgMzMTmZmZAIAVK1YgOzsbAJCeno6cnBwAwOLFi5GXlwcAmD9/PvLz8wEAKSkpKCgoAADMnj0bRUVFAIDk5GQ8+eST0DQNSUlJqKiogK7rSEpKgq7rqKioQFJSEgCgtLQUycnJAICioiLMnj07MN+UlBQAQH5+Pt5f8g4AwPQr/PftxQCAnJycwHsTs7OzsWLFClvnVFpaCgBhm9P8+fMBAHl5eVi82N45fffdd5g+fbqj5uSETm+88QaeeuopaJrmmDk5oVPt9lJubq5j5hTtnT744AM8/fTT0DTNMXNyQidN0/D0009j9erVts2pdrxBUUIAUEuXLj3hc4YPH67i4uLUgQMHAo+9++67yuVyqcrKyuN+X3V1tSorKwt8FRYWKgCqtLRUKaWUYRjKMAyllFK6rtd7rGmaMk2z3mPLsgI/p/a4qqpK/fzzz8rv96vq6mrl9/vrPVZKKcuyjnusaZpSSinTNNXByirV+eEPVOeHP1A//nwwMHZd1+s9Dvecjj4Ox5zqO7ZrTqZpqrKyMlVVVeWYOTmhU3V1tfrpp5+U3+93zJyc0Mnv96vS0tLjzi8a5xTtnTRNU/v371d+v98xc3JCJ7/fr/bv3x943I45lZSUKACqrKxMnUxUvcduwoQJWLduHbZv3x547Ntvv0XPnj2xbds2nH/++UH9rMZ4j51SCrquIzY2Fi6XK2yve8E/V0A3/Vj3yK/R/owmYXvd04FdTejUsItM7CIPm8jUGF0c+x67yy+/HHv37sXBgwcDj23btg1utxsdOnSI4MiOdeQp4HBqVnvLE96kOGR2NaFTwy4ysYs8bCKTtC4RPWN38ODBwNm3fv36ITk5GVdddRVatmyJTp06YerUqSgqKsKbb74ZeH6PHj0waNAgTJ8+HaWlpZg4cSKGDRuGV199NeifG81n7C5P+hhFB6qQfs/luLjjGWF73dMB/7YrE7vIxC7ysIlMPGN3hC+//BL9+vVDv379AABTpkxBv3798NhjjwEAiouLsXv37sDzmzdvjoyMDBw4cAADBw7ErbfeilGjRuH555+PyPhPJpSrWILVlDcpPiV2NKFTxy4ysYs8bCKTpC4RXdhdeeWVgcuQj/yaN28eAGDevHnIysqq8z3du3dHRkYGKisrUVhYiGeffRZNmsh7r5mu65g5c2bYT8029R2+SbHGmxSHyq4mdGrYRSZ2kYdNZJLWRczFE42pMbZi7XLLqxvw2Y79eO6mi3Hdxe0jPRwiIiKyWdRsxTqZ3+9HSUlJ4OaC4dKUHyvWYHY1oVPDLjKxizxsIpO0LlzY2cQwDKSmpgbuUB0uv7zHjgu7UNnVhE4Nu8jELvKwiUzSunArNsq2Yqcu+QoLvyjE34ZfgPuuDu6+fURERBS9uBUrgN/vR2FhoW1bsYd4xi5kdjWhU8MuMrGLPGwik7QuXNjZxDAMpKWlhf3UbDPe7qTB7GpCp4ZdZGIXedhEJmlduBUbZVuxc7N24P+tzMefBnTAf8b2jfRwiIiIyGbcihXA7/dj+/btYT8128zHM3YNZVcTOjXsIhO7yMMmMknrwoWdTUzTxOrVq2Ga4V2ABd5jxxsUh8yuJnRq2EUmdpGHTWSS1oVbsVG2Fbvi62L85a2NuKTLmUibdFmkh0NEREQ241asAJZlYcuWLbCs8J5Zq/1IMZ6xC51dTejUsItM7CIPm8gkrQsXdjaxLAsbNmwI/8Lu8FWxVYaM/4CiiV1N6NSwi0zsIg+byCStC7dio2wrdsveMlz7fDZax/vwxaO/ifRwiIiIyGbcihXAsixs3Lgx7Cv4Zvys2AazqwmdGnaRiV3kYROZpHXhws4mlmVh69atNrzHrmYr9pBu4jQ82XpK7GpCp4ZdZGIXedhEJmlduBUbZVuxBzUTvR9fBQDIf/K3iIvxRHhEREREZCduxQpgmibWr18f9vvaNDliIXdIk3HPnGhhVxM6NewiE7vIwyYySevChZ1NlFLYs2dP2LdLPW5XYHHH99mFxq4mdGrYRSZ2kYdNZJLWhVuxUbYVCwADn8pA6UEdKx8Ygu5to2/8REREFDxuxQpgmiaysrJsOTXbJJZn7BrCzibUcOwiE7vIwyYySevChZ1NlFIoLy+35dRs4JYn/PSJkNjZhBqOXWRiF3nYRCZpXbgVG4VbsWPmrMPG3Qfw8m0DcE2vtpEeDhEREdmIW7ECmKaJVatW2XJqtpmv9ibFMk77Rgs7m1DDsYtM7CIPm8gkrQsXdlGo9qrYQ9yKJSIioiNwKzYKt2IfXLQZSzcV4dHf9cBdQ7tFejhERERkI27FCmAYBpYtWwbDMML+2k1jf/lYMQqenU2o4dhFJnaRh01kktaFCzubuFwutGjRAi6XK+yv/ct77LgVGwo7m1DDsYtM7CIPm8gkrQu3YqNwK3bWR9sw66PvceulnfD09RdFejhERERkI27FCmAYBtLS0mzdiq3iGbuQ2NmEGo5dZGIXedhEJmlduLCzicvlQocOHWw5Ndv08A2K+R670NjZhBqOXWRiF3nYRCZpXbgVG4VbsUs37cGDi/Iw5PxWmH/npZEeDhEREdmIW7EC6LqOBQsWQNf1sL924IydxjN2obCzCTUcu8jELvKwiUzSunBhZxOPx4OePXvC4/GE/bVr32PHq2JDY2cTajh2kYld5GETmaR18UZ6AE7l8XjQv39/W1679owdF3ahsbMJNRy7yMQu8rCJTNK68IydTXRdR2pqqi2nZpv5as/YcSs2FHY2oYZjF5nYRR42kUlal4gu7NauXYtRo0ahXbt2cLlcSE9PD/p7161bB6/Xi4svvti28Z0Kj8eDQYMG2XJqtlngPXY8YxcKO5tQw7GLTOwiD5vIJK1LRBd2hw4dQt++ffHiiy+G9H1lZWUYP348rr76aptGduo8Hg969eplS+gmtfexMyz4/afdRc0NZmcTajh2kYld5GETmaR1iejCbuTIkXjqqacwZsyYkL7v7rvvxi233ILBgwfbNLJTp+s65syZY89WbOwvb42sMnjWLlh2NqGGYxeZ2EUeNpFJWpeoe4/d66+/jh07duDxxx+P9FBOyOv1YsSIEfB6w399SlyMG7X3QeRNioNnZxNqOHaRiV3kYROZpHWJqoXd999/j0ceeQRvvfVWSP8CNU1DeXl5nS8AgY//ME0TpmkGHqvvWNd1WJZV77Hf7w/8nNpjwzDQrVs3uN1uaJoGpRSUUsccA4Df7z/uce3fACzLChz7/f7ALU/KK7U687BzTkcfh3NORx4fPY9wzQkAzjvvPBiG4Zg5OaGTaZro2rUr3G63Y+bkhE5utxudOnVC7T3snTCnaO9kWRa6dOkCt9vtmDk5oZPb7UaXLl3q/P+/HXMKVtQs7CzLwi233ILp06fjggsuCOl7ExMTkZCQEPjq2LEjACAjIwMAkJmZiczMTADAihUrkJ2dDQBIT09HTk4OAGDx4sXIy8sDAMyfPx/5+fkAgJSUFBQUFAAAZs+ejaKiIgBAcnIynn32WWiahqSkJFRUVEDXdSQlJUHXdVRUVCApKQkAUFpaiuTkZABAUVERZs+eDQAoKChASkoKACA/Px/z588HAOTl5cFt1fyHlbPpq8BFJ9nZ2VixYoWtcyotLQUAW+a0ePHimjnl5Ngyp++++w7JycmOmpMTOr3xxhv4z3/+A03THDMnJ3TSNA0zZsxAbm6uY+YU7Z0++OAD/Pvf/4amaY6ZkxM61f6urF692rY51Y43KEoIAGrp0qXH/fOff/5ZAVAejyfw5XK5Ao9lZmYe93urq6tVWVlZ4KuwsFABUKWlpUoppQzDUIZhKKWU0nW93mNN05RpmvUeW5YV+Dm1x5WVlWrXrl3KsixVXV2t/H6/8vv9xxwrpQLPqe9Y0zSllFKmadY5Hvr/MlXnhz9QG7aXKF3XA/M48jjcczr6ONxzqj0+eh7hmpNhGGr37t2qsrLSMXNyQqeqqqrA74pT5uSETpZlqR07dgSe74Q5RXun6upqtXPnTmVZlmPm5IROlmWpgoKCwHPsmFNJSYkCoMrKytTJiPmsWJfLhaVLl2L06NH1/rnf78fWrVvrPDZnzhx8/PHHeOedd9C1a1c0a9YsqJ8V7Z8VCwC/e+5TbC0uxxt3/ArDLjg70sMhIiIim0TNZ8UePHgQmzdvxubNmwEAO3fuxObNm7F7924AwNSpUzF+/HgAgNvtRu/evet8tW7dGnFxcejdu3fQi7rGomkaEhMTQ9oXD0XgJsX8vNig2d2EGoZdZGIXedhEJmldInoJx5dffomrrroq8M9TpkwBAEyYMAHz5s1DcXFxYJEXbWJiYnDnnXciJibGltev/VixQ/xYsaDZ3YQahl1kYhd52EQmaV3EbMU2Jidsxf5lQS5WfLMPT17XC7cN7hLp4RAREZFNomYr1sk0TcP06dNtOzXLM3ahs7sJNQy7yMQu8rCJTNK68IydTWfslFKoqKhAfHw8XLV3Ew6jx977Bm+u/wGTf30epoy4MOyv70R2N6GGYReZ2EUeNpGpMbrwjJ0QPp/PttfmGbuGsbMJNRy7yMQu8rCJTJK6cGFnkyNvjGiH2k+eqOTCLmh2N6GGYReZ2EUeNpFJWhduxdq4FavrOmJjY205NZvyaQGe+vBbXHdxOzx3U7+wv74T2d2EGoZdZGIXedhEpsbowq1YIex8I2Uz3+GtWI1n7EIh5c2tVBe7yMQu8rCJTJK6cGFnE13XMXPmzEbYiuUNioNldxNqGHaRiV3kYROZpHXhVmyU3sfuo60/YuKbX6JvxzPw3j2XR3o4REREZBNuxQrg9/tRUlICv99vy+vXnrGr4hm7oNndhBqGXWRiF3nYRCZpXbiws4lhGEhNTYVhGLa8flO+xy5kdjehhmEXmdhFHjaRSVoXbsVG6Vbs9z9WYPjMtTizaQw2PTYi0sMhIiIim3ArVgC/34/CwkL7tmJ9vEFxqOxuQg3DLjKxizxsIpO0LlzY2cQwDKSlpdm3FRtT8x473fTDtGT8xySd3U2oYdhFJnaRh01kktaFW7FRuhWrmRYu/OdKAMBX00agRVxMhEdEREREduBWrAB+vx/bt2+37dRsrMcNr7vmDteVvIAiKHY3oYZhF5nYRR42kUlaFy7sbGKaJlavXg3TtOd2JC6XK3DLk0O85UlQ7G5CDcMuMrGLPGwik7Qu3IqN0q1YABj0TCb2lVfjg/uuQO/2CZEeDhEREdmAW7ECWJaFLVu2wLLs2yZt6jt8xk6T8bcE6RqjCYWOXWRiF3nYRCZpXbyRHoBTWZaFDRs24Pzzz4fH47HlZzSLrclXdKAK+8qqbfkZEiU0iUGT2ND/nTZGEwodu8jELvKwiUzSunArNoq3Ym98eT0+3/lTpIfR6JrFerB6yjC0P6NJpIdCRERkO27FCmBZFjZu3GjrqdnfXXQOmsR4EONxnTZfQM1NmfOLy0P+99UYTSh07CITu8jDJjJJ68KtWJtYloWtW7eid+/etp2anXBZF0y4rIstry3VDS+txxe7fkK1Efpl5Y3RhELHLjKxizxsIpO0LtyKjeKt2NPRbamf49PvS5F8Q1+M6d8h0sMhIiKyHbdiBTBNE+vXrxdzXxun8Hlr/jbUkDN2bCITu8jELvKwiUzSunBhZxOlFPbs2YPT8ISoreJiav6TrTZCfy8Dm8jELjKxizxsIpO0LtyK5VZsVPnb4jy8u3EPHv5td/zlynMjPRwiIiLbcStWANM0kZWVJebUrFOcyhk7NpGJXWRiF3nYRCZpXbiws4lSCuXl5WJOzTpFXEzNe+w0M/T32LGJTOwiE7vIwyYySevCrVhuxUaVGSvzMSdrB26/rAum/aFXpIdDRERkO27FCmCaJlatWiXm1KxT/HLGrmFbsWwiD7vIxC7ysIlM0rpwYUdRxeet+U9Wa8DtToiIiJyOW7Hcio0qb3y2C48v24LfXdQWc24dEOnhEBER2Y5bsQIYhoFly5bBMIxID8VRfrkqNvQzdmwiE7vIxC7ysIlM0rpwYWcTl8uFFi1awOVyRXoojlL7yRMNeY8dm8jELjKxizxsIpO0LtyK5VZsVFn5TTEmLdiIAZ3PxLt/uSzSwyEiIrIdt2IFMAwDaWlpYk7NOoUvpvazYkM/Y8cmMrGLTOwiD5vIJK1LRBd2a9euxahRo9CuXTu4XC6kp6ef8PlLlizB8OHDcfbZZ6NFixYYPHgwVq1a1TiDDZHL5UKHDh3EnJp1isBVsQ24QTGbyMQuMrGLPGwik7QuEV3YHTp0CH379sWLL74Y1PPXrl2L4cOHY/ny5cjNzcVVV12FUaNGYdOmTTaPNHRerxeDBw+G1+uN9FAcJe4UztixiUzsIhO7yMMmMknrEtGF3ciRI/HUU09hzJgxQT1/1qxZeOihh3DJJZfg/PPPxzPPPIPzzz8f77//vs0jDZ2u61iwYAF0XY/0UBwlztvwjxRjE5nYRSZ2kYdNZJLWJarfY+f3+1FRUYGWLVtGeijH8Hg86NmzJzweT6SH4ii+wO1OQj9jxyYysYtM7CIPm8gkrUtUL+yeffZZHDp0CDfccMMJn6dpGsrLy+t8AQi80dE0zcBHgRiGUe+xruuwLKveY7/fH/g5tcemaeLiiy+Gx+OBpmlQSkEpdcwxULNAPd5x7d8ALMuq99g0zTrzsHNORx9HYk4xrpqLuKsNK+Q5uVwu9O/fH6ZpipqTEzuFMifLstC3b194PB7HzMkJnTweD3r37o1aTphTtHfy+/3o06cPPB6PY+bkhE4ejwd9+vRB7U1G7JpTsKJ2Ybdw4UJMmzYNixYtQuvWrU/43MTERCQkJAS+OnbsCADIyMgAAGRmZiIzMxMAsGLFCmRnZwMA0tPTkZOTAwBYvHgx8vLyAADz589Hfn4+ACAlJQUFBQUAgNmzZ6OoqAgAkJycjFdeeQW6riMpKQkVFRWBY13XUVFRgaSkJABAaWkpkpOTAQBFRUWYPXs2AKCgoAApKSkAgPz8fMyfPx8AkJeXh8WLFwMAcnJyAhedZGdnY8WKFbbOqbS0FAAiNqfP168DABiWwtpPPw1pTtu2bUNqaqq4OTmxUyhzeuONNzBnzhzouu6YOTmhk67rSE5ORm5urmPmFO2dPvzwQzz//PPQdd0xc3JCJ13X8dxzz2H16tW2zal2vMEI+T52u3btwqeffopdu3ahsrISZ599Nvr164fBgwcjLi4ulJeqOxCXC0uXLsXo0aNP+txFixbhz3/+M9LS0nDttdee9PmaptVZ7ZaXl6Njx44oLS3FWWedFVhNe71eGIYBl8t1zLGu6/B4PIGzCkcee71euN1uaJqGmJgYuN1uVFZWoqCgAD169IBpmoiNjQVQszI/8tjn88Hv98MwjHqPa7/XsixYlnXMsWmaUEohJibmmONwz+no40jM6aBm4uIna/4H4evHfoP4pr6g5+RyubBt2zZ07doVcXFxYubkxE6hzKmqqgrbt29Hz549YVmWI+bkhE4ulwvffPMNevTogdjYWEfMKdo7VVdXY9u2bejVqxf8fr8j5uSETm63G1u2bMGFF14In89ny5z+97//oXXr1kHdxy7ohd1///tfPP/88/jiiy/QunVrtG/fHk2aNMFPP/2EHTt2IC4uDrfeeisefvhhdO7cOZiXrDuQIBd2CxcuxB133IGFCxcGtQisD29QHL1My4/zHq35W9+mfw3Hmc1iIzwiIiIie4X9BsX9+/dHcnIyxo0bh127dmHfvn3Izc1FdnY2tm7divLycrz33nvw+/0YOHAg0tLSghrowYMHsXnzZmzevBkAsHPnTmzevBm7d+8GAEydOhXjx48PPH/hwoUYP348nn32WQwaNAj79u3Dvn37UFZWFtTPa0y6rge2lyh8vB43PO6aewWFemUsm8jELjKxizxsIpO0LkGdsfvwww+D2vIEavaud+7ciUsuueSkz83KysJVV111zOMTJkzAvHnzcPvtt2PXrl3IysoCAFx55ZVYs2bNcZ8frMY4Y+f3+1FQUIBu3brB7Y7atzKK1OuxlTikW8j6+5Xo0qpZ0N/HJjKxi0zsIg+byNQYXUJZt/CzYrkVG3UGPJmB/Yd0rHxgCLq3ZT8iInK2Rvms2JKSEnzzzTf46quv6nxRDU3TkJycHNIlyhScwMeKGaFtxbKJTOwiE7vIwyYySesS8udf5ObmYsKECfj2228D92xxuVxQSsHlcgXuy3K6i4mJwdixYxETExPpoThOQz9WjE1kYheZ2EUeNpFJWpeQF3Z//vOfccEFFyA1NRVt2rQR86G30rjd7sD98ii8fDEN+1gxNpGJXWRiF3nYRCZpXULeit25cydmzJiBSy+9FF26dEHnzp3rfFENTdOQmJgo5tSsk9RuxYZ6xo5NZGIXmdhFHjaRSVqXkBd2V199deDOyXR8MTExuPPOO8WcmnWSuNrPiw3xjB2byMQuMrGLPGwik7QuIW/FpqSkYMKECfjmm2/Qu3fvYybyhz/8IWyDi2Zut/ukH3VGDePzHt6KDfGMHZvIxC4ysYs8bCKTtC4hn7H77LPPkJ2djenTp2Ps2LEYPXp04Ov666+3Y4xRSdM0TJ8+XcypWSdp6Bk7NpGJXWRiF3nYRCZpXUK+j12XLl3w+9//Hv/617/Qpk0bu8Zlq8a4j51SChUVFYiPj+cFJmF2/9ub8N7mvfjntT0wcUi3oL+PTWRiF5nYRR42kakxuth6H7v9+/fjwQcfjNpFXWPy+XyRHoIjBe5jF+IZO4BNpGIXmdhFHjaRSVKXkBd2Y8aMwSeffGLHWBxF13UkJSWJ+ew4J2nofezYRCZ2kYld5GETmaR1CXkr9umnn8asWbNw7bXX4qKLLjrm4onJkyeHdYB2aKytWF3XERsby1PmYfbM8m/xytoC3DWkKx69tmfQ38cmMrGLTOwiD5vI1BhdQlm3NOiq2ObNm2PNmjVYs2ZNnT9zuVxRsbBrLJqmITY2NtLDcJxT2YplE5nYRSZ2kYdNZJLUpUE3KD7eV0FBgR1jjEq6rmPmzJliTs06yalsxbKJPOwiE7vIwyYySesS8lasEzTGVizZJ+XTAjz14be47uJ2eO6mfpEeDhERka1s3YpVSuGdd97BJ598gpKSEvj9dbfDlixZEupLOpLf70dpaSlatWoFtzvkE6N0Ar4GnrFjE5nYRSZ2kYdNZJLWJeQR3H///bjtttuwc+dONG/eHAkJCXW+qIZhGEhNTYVhGJEeiuPEBT4rNrT32LGJTOwiE7vIwyYySesS8lZsy5YtsWDBAvzud7+za0y241ZsdFuWtxeTF27CoG4t8fb/GRzp4RAREdnK1hsUJyQkoFu34O/2f7ry+/0oLCw8ZquaTl1Dz9ixiUzsIhO7yMMmMknrEvLCbtq0aZg+fTqqqqrsGI9jGIaBtLQ0MadmnaShV8WyiUzsIhO7yMMmMknrEvJWbGVlJcaMGYN169ahS5cux9ygeOPGjWEdoB24FRvdPi/Yjxtf2YBurZrh479fGenhEBER2crWq2Jvv/125ObmYty4cWjTpg3vfn0cfr8fBQUF6Natm4irZJykoWfs2EQmdpGJXeRhE5mkdQl5Yffhhx9i1apVuOKKK+wYj2OYponVq1dj4sSJYu5G7RSBhV2InzzBJjKxi0zsIg+byCStS8hbsd27d8fixYvRp08fu8ZkO27FRrddpYdw5X+y0CzWgy1P/DbSwyEiIrKVrVfFPvvss3jooYewa9euho7vtGBZFrZs2QLLCm27kE6uoWfs2EQmdpGJXeRhE5mkdQl5YTdu3Dh88sknOPfccxEfH4+WLVvW+aIalmVhw4YNYkI7ie/w7U4sv4JpBb+4YxOZ2EUmdpGHTWSS1iXkrdg33njjhH8+YcKEUxpQY+BWbHSr0i30eGwlAOCb6deguS/kt4oSERFFDVuvio2GhZsElmUhLy8Pffv2hcfjifRwHKX2jB1Qc2VssAs7NpGJXWRiF3nYRCZpXYLaij106FBILxrq853Isixs3bpVzKlZJ3G7XYj11Pynq4XwPjs2kYldZGIXedhEJmldgtqKPeecc3Dffffh9ttvR7t27ep9jlIKH330EZKTkzF06FBMnTo17IMNF27FRr+Lpq1CRbWJzL8Nw7lnN4/0cIiIiGwT9qtis7KysGnTJnTt2hWXXnop7rnnHjz99NN49tln8c9//hNjxoxBu3btcOedd+IPf/gDHnroobBMJJqZpon169fDNM1ID8WRGnKTYjaRiV1kYhd52EQmaV2CWthdeOGFSEtLw44dO3DTTTdh7969eOedd/Dqq68iKysL7du3x6uvvopdu3bhL3/5i4g95khTSmHPnj0I8doUClLt++xC2YplE5nYRSZ2kYdNZJLWJeSrYp2AW7HR7zfJa7C95CD+e9eluOzcVpEeDhERkW1svUExBcc0TWRlZYk5Nes0cTGHz9gZwZ+xYxOZ2EUmdpGHTWSS1oULO5sopVBeXi7m1KzT+Lw12/2aGfx77NhEJnaRiV3kYROZpHXhViy3YqPSrSkbsG77fsy68WKM7tc+0sMhIiKyDbdiBTBNE6tWrRJzatZpGnLGjk1kYheZ2EUeNpFJWpeILuzWrl2LUaNGoV27dnC5XEhPTz/p96xZswYDBgxAXFwcunXrhpdeesn+gZI4te+xqw7hPXZEREROF/LCrkuXLnjiiSewe/fuU/7hhw4dQt++ffHiiy8G9fydO3fid7/7HYYMGYJNmzbhH//4ByZPnox33333lMcSbl6vF9dccw28Xn6OqR3ivKHfx45NZGIXmdhFHjaRSVqXkBd2f/vb3/Dee++hW7duGD58ON5++21omtagHz5y5Eg89dRTGDNmTFDPf+mll9CpUyfMmjULPXr0wMSJE3HHHXfgP//5T4N+vp0Mw8CyZctgGEakh+JIvpjQ72PHJjKxi0zsIg+byCStS8gLu/vuuw+5ubnIzc1Fz549MXnyZJxzzjm49957sXHjRjvGGLB+/XqMGDGizmPXXHMNvvzyyxP+C9U0DeXl5XW+AAS+xzTNwN64YRj1Huu6HvgcuKOP/X5/4OfUHuu6jvj4eLhcLmiaBqUUlFLHHAOA3+8/7rGu6wBqPouuvmPTNOvMw845HX0cyTnFuF0Aas7YBTsnpRRatGhxwvmxU+PPyTAMNG/eHC6XyzFzckInl8uFZs2a1fnftGifU7R3Mk0z8LvilDk5oZPL5ULz5s3r/G+aHXMKVoPfY9e3b18899xzKCoqwuOPP46UlBRccskl6Nu3L1577TVbLvvdt28f2rRpU+exNm3awDRNlJaWHvf7EhMTkZCQEPjq2LEjACAjIwMAkJmZiczMTADAihUrkJ2dDQBIT09HTk4OAGDx4sXIy8sDAMyfPx/5+fkAgJSUFBQUFAAAZs+ejaKiIgDA888/j169esHr9SIpKQkVFRXQdR1JSUnQdR0VFRVISkoCAJSWliI5ORkAUFRUhNmzZwMACgoKkJKSAgDIz8/H/PnzAQB5eXlYvHgxACAnJyfw3sTs7GysWLHCtjklJycH/j1Hek57C3cBqHmPXbBz2r17N6688kq8/PLLIufkxE7BzGnhwoVo06YNvF6vY+bkhE5erxfFxcXYsmWLY+YU7Z0yMjLgdrvh9XodMycndPJ6vTAMA2vWrLFtTrXjDYpqIF3X1aJFi9Rvf/tb5fF41OWXX65ee+019dRTT6m2bduqm2++OaTXA6CWLl16wuecf/756plnnqnzWHZ2tgKgiouLj/t91dXVqqysLPBVWFioAKjS0lKllFKGYSjDMALzqu9Y0zRlmma9x5ZlBX5O7XFFRYVatGiR0nVdVVdXK7/fr/x+/zHHSillWdZxjzVNU0opZZpmvceGYShd1+s9Dvecjj6O5Jz+s3Kr6vzwB+ofS74Kek7V1dVq8eLFqqKiQuScnNgpmDkdPHgw8LvilDk5oZOu6+rtt99WVVVVjplTtHc6dOiQevvtt5Wu646ZkxM61f6uVFZW2jankpISBUCVlZWpkwn5nX4bN27E66+/joULF8Lj8eC2227DzJkz0b1798BzRowYgaFDh4b60ifVtm1b7Nu3r85jJSUl8Hq9OOuss477fT6fDz6f75jHY2JiAKDOGx5rHzv6ODY29qTHR/6MuLg4dOzYES6Xq87j9R273e7jHte+vsfjCXwG75HHR479eMfhmlMox3bPqamv5jWqDX/QczJNEx06dEBcXBzcbre4OTmxUzBz8vl8gd+VI58TzXNyQifTNNGpU6fA85wwpxPNIxrmFBsbi06dOsHlch3zeLTOyQmdan9Xasdv95xOJuSF3SWXXILhw4dj7ty5GD16dJ1B1+rZsyduuummUF/6pAYPHoz333+/zmOrV6/GwIED6x1HJHm9XgwePDjSw3CswO1OQriPHZvIxC4ysYs8bCKTtC4hv8euoKAAK1euxNixY4+7mGrWrBlef/31k77WwYMHsXnzZmzevBlAze1MNm/eHLiVytSpUzF+/PjA8ydNmoQffvgBU6ZMwbfffovXXnsNqamp+Pvf/x7qNGyn6zoWLFgQeMMlhVfgBsUh3MeOTWRiF5nYRR42kUlal5AXdt9///1x/+zll18O6bW+/PJL9OvXD/369QMATJkyBf369cNjjz0GACguLq5zv7yuXbti+fLlyMrKwsUXX4wnn3wSzz//PP74xz+GOg3beTwe9OzZM3D6lsIrLnC7k+DP2LGJTOwiE7vIwyYySesS8mfF+nw+3HvvvUhMTAzsC//vf//DHXfcgXXr1uGnn36yZaDhxM+KjX4fflWMe/67Eb/q0hKLJ8k5BU5ERBRutn5W7Nq1a/H+++/jkksuwZYtW/Dhhx+id+/eOHjwYOAyXqo5NZuamirm1KzTNOQ9dmwiE7vIxC7ysIlM0rqEvLC79NJLsWnTJvTp0wcDBgzA9ddfj7/97W/4+OOPA/eHo5pTs4MGDRJzatZp4mJC/0gxNpGJXWRiF3nYRCZpXRp0g+LvvvsOOTk56NChA7xeL/Lz81FZWRnusUU1j8eDXr16iQntND5v6B8pxiYysYtM7CIPm8gkrUvIC7ukpCQMHjwYw4cPxzfffIOcnJzAGbz169fbMcaopOs65syZI+bUrNM05Iwdm8jELjKxizxsIpO0LiEv7J577jmkp6fjhRdeQFxcHHr16oUvvvgCY8aMwZVXXmnDEKOT1+vFiBEj6tzMkMIn8B67EG53wiYysYtM7CIPm8gkrUvIV8WWlpaiVatW9f7ZmjVrMGzYMADAnj170K5du8Ad/iXhVbHRr/CnSgyZ8QniYtzIf3JkpIdDRERkG1uvij3eog5AYFEH1Hz6xK5du0J9ecfQNA3JycnQNC3SQ3Ek3xFn7IL9uwmbyMQuMrGLPGwik7Qutp1OC/FEoOPExMSc8NM56NTUvscOCP4CCjaRiV1kYhd52EQmaV1kbAg7kNvt5u1fbFR7VSxQs7A7cqF3PGwiE7vIxC7ysIlM0rrIewOcQ2iahsTERDGnZp0m1uOGy1VzrAV5ZSybyMQuMrGLPGwik7QuIV88Eaz4+Hjk5eWhW7dudrz8KWmMiyf8fn/gQhOJF5A4Qfd/rUC14cenD12Fji2bnvT5bCITu8jELvKwiUyN0SWUdYttW7Gu2tMppym3243WrVtHehiOFhfjQbXhD/pedmwiE7vIxC7ysIlM0rrw4gmbaJqG6dOnizk160Rx3tqbFAd38QSbyMQuMrGLPGwik7Qutm3FFhYWol27dmI+YuNIjbEVq5RCRUUF4uPjT/uzl3YZ9u9P8MP+SrwzaTAGdml50ueziUzsIhO7yMMmMjVGF9u3YnNycpCWlobdu3cf8xEaS5YsAQBRV4hEis/ni/QQHC3UM3YAm0jFLjKxizxsIpOkLiFvxb799tu4/PLLsXXrVixduhSGYWDr1q34+OOPkZCQYMcYo5Ku60hKShLz2XFO9MvHigX3Hjs2kYldZGIXedhEJmldQt6K7dOnD+6++27cc889gStfu3btirvvvhvnnHMOpk+fbtdYw6axtmJ1XUdsbCxPmdvkhpfW44tdP2H2Lf1xbZ9zTvp8NpGJXWRiF3nYRKbG6GLrR4rt2LED1157LYCaU4+HDh2Cy+XCgw8+iFdeeaVhI3YoKW+kdCpfiGfsADaRil1kYhd52EQmSV1CXti1bNkSFRUVAID27dvjm2++AQAcOHAAlZWV4R1dFNN1HTNnzhRzataJaj9tItiPFGMTmdhFJnaRh01kktYl5K3YW265BQMHDsSUKVPw9NNP47nnnsN1112HjIwM9O/fP3DxhGSNsRVL9rv3vxvxwVfFeOz3PXHHFV0jPRwiIiJb2HpV7Isvvojq6moAwNSpUxETE4Ps7GyMGTMG//rXvxo2YgfiHcLtV3vGrtoMbiuWTWRiF5nYRR42kUlalwZtxbZr167mm91uPPTQQ1i2bBmSk5Nx5plnhn2A0cowDKSmpsIwjEgPxbF83pr/fLUgb3fCJjKxi0zsIg+byCStS4NvUFxSUoKSkhL4/XX/T7VPnz5hGZiduBXrDE9+sBWp2Ttx97BumDqyR6SHQ0REZAtbt2Jzc3MxYcIEfPvtt8d8bJjL5YJlBX+FopP5/X4UFRWhffv2Ik7NOlHtfeyCPWPHJjKxi0zsIg+byCStS8gj+POf/4wLLrgAn332GQoKCrBz587AV0FBgR1jjEqGYSAtLU3MqVkn8nlrr4oN7i8TbCITu8jELvKwiUzSuoS8FRsfH49NmzbhvPPOs2tMtuNWrDO8snYHnlmej+v7tcfMGy+O9HCIiIhsYesNiq+++mrk5eU1eHCnC7/fj+3btx/zHkQKn8BVsUHeoJhNZGIXmdhFHjaRSVqXkBd2KSkpeO211zB9+nS8++67WLZsWZ0vqmGaJlavXg3TNCM9FMcKXBUb5A2K2UQmdpGJXeRhE5mkdQl5K3bZsmW47bbbAp8+UefFouTiCW7FOsN7m4tw/9ubcdm5Z+G/dw2K9HCIiIhsYetW7OTJk3HbbbehuLgYfr+/zlc0LOoai2VZ2LJlC/+d2OiXiyeCO2PHJjKxi0zsIg+byCStS8gLu/379+PBBx9EmzZt7BiPY1iWhQ0bNogJ7US+w7c7CfY9dmwiE7vIxC7ysIlM0rqEvBU7YcIEDBkyBBMnTrRrTLbjVqwzrN+xHze/ugHnnt0MmX+7MtLDISIisoWtNyi+4IILMHXqVGRnZ+Oiiy5CTExMnT+fPHlyqC/pSJZlIS8vD3379oXH44n0cByp9oxdKFuxbCIPu8jELvKwiUzSuoS8sEtJSUHz5s2xZs0arFmzps6fuVwuLuwOsywLW7duRe/evUWEdqI4b+3tToJf2LGJPOwiE7vIwyYySevS4M+KjWbcinWGgv8dxK+fXYN4nxdfT78m0sMhIiKyha1Xxdphzpw56Nq1K+Li4jBgwAB8+umnJ3z+W2+9hb59+6Jp06Y455xz8Oc//xn79+9vpNEGxzRNrF+/Xsx9bZzIFxPaVbFsIhO7yMQu8rCJTNK6hLwVO2XKlHofd7lciIuLw3nnnYfrrrsOLVu2DOr1Fi1ahAceeABz5szB5ZdfjpdffhkjR47E1q1b0alTp2Oen52djfHjx2PmzJkYNWoUioqKMGnSJEycOBFLly4NdTq2UUphz549GDhwYKSH4lhxh29QrFt+WH4Fj9t1wueziUzsIhO7yMMmMknrEvJW7FVXXYWNGzfCsixceOGFUErh+++/h8fjQffu3fHdd9/B5XIhOzsbPXv2POnrXXrppejfvz/mzp0beKxHjx4YPXo0EhMTj3n+f/7zH8ydOxc7duwIPPbCCy9gxowZKCwsDGoO3Ip1hkOaiV6PrwIAbH3iGjSNDfnvKUREROLZuhV73XXX4Te/+Q327t2L3NxcbNy4EUVFRRg+fDhuvvlmFBUVYejQoXjwwQdP+lq6riM3NxcjRoyo8/iIESPw2Wef1fs9l112Gfbs2YPly5dDKYUff/wR77zzDq699tpQp2Ir0zSRlZUl5tSsE9V+pBgAaEFcQMEmMrGLTOwiD5vIJK1LyAu7f//733jyySfrrBhbtGiBadOmYcaMGWjatCkee+wx5ObmnvS1SktLYVnWMTc7btOmDfbt21fv91x22WV46623cOONNyI2NhZt27bFGWecgRdeeOG4P0fTNJSXl9f5AgDDMADURKkNYhhGvce6rgduPnj0ce0H/2qaFjiurq5GWVkZlFLQNA1KqXqPgZoPED7esa7rAGquuqnv2DTNOvOwc05HH0d6TlB+eA9vvx6s1k86J8uyUF5ejurqarFzcmKnk81J07TA74pT5uSETkop/Pzzz8edXzTOKdo76bqOAwcOQCnlmDk5oZNSCgcOHAg8btecghXywq6srAwlJSXHPP6///0vsGA644wzAv8SguFy1X1vlFLqmMdqbd26FZMnTw4sHleuXImdO3di0qRJx339xMREJCQkBL46duwIAMjIyAAAZGZmIjMzEwCwYsUKZGdnAwDS09ORk5MDAFi8eDHy8vIAAPPnz0d+fj6Amtu/FBQUAABmz56NoqIiADXbw4MHD0ZMTAySkpJQUVEBXdeRlJQEXddRUVGBpKQkADUL3OTkZABAUVERZs+eDQAoKChASkoKACA/Px/z588HAOTl5WHx4sUAgJycHKSnpwOoef/hihUrbJtTcnIySktLAUDMnOIOX0Dx5cbNJ51TYWEh/vCHP+CVV14RPScndjrRnN5++22cd955iImJccycnNApJiYGhw4dwtatWx0zp2jv9NFHH+GMM85ATEyMY+bkhE4xMTFo0qQJ1q5da9ucascbFBWiW265RXXt2lUtWbJEFRYWqj179qglS5aobt26qXHjximllFq4cKEaMGDASV9L0zTl8XjUkiVL6jw+efJkNXTo0Hq/Z9y4cepPf/pTncc+/fRTBUDt3bu33u+prq5WZWVlga/CwkIFQJWWliqllDIMQxmGoZRSStf1eo81TVOmadZ7bFlW4OfUHh88eFCtWLFCGYahqqurld/vV36//5hjpZSyLOu4x5qmKaWUMk2z3mPDMJSu6/Ueh3tORx9LmFP/J1arzg9/oL4p/Omkc9I0Ta1cuVIdPHhQ9Jyc2OlEczp06JBavny5MgzDMXNyQifDMNSHH34Y+FlOmFO0d6qsrAz8rjhlTk7oZBiGWr58uaqqqrJtTiUlJQqAKisrUycT8rvNX375ZTz44IO46aabAqcXvV4vJkyYgJkzZwIAunfvHlj1nkhsbCwGDBiAjIwMXH/99YHHMzIycN1119X7PZWVlfB66w679oaA6jjXgfh8Pvh8vmMer/3UjCNf78hP0jjyODY29qTHR/4Mn88XOOt49ONHH7vd7uMe176+x+MJzPPI4yPHfrzjcM4p2OPGmlPtGTtDuU46p9r/Xn0+H9xut9g5HX3shE4nm1NtDyfNqb7jaJqTaZp1XscJczrRPKJlTrW/K06aU33H0TQn0zThdrsD/2z3nE6mwTcoPnjwIAoKCqCUwrnnnovmzZs35GWwaNEi3HbbbXjppZcwePBgvPLKK3j11VexZcsWdO7cGVOnTkVRURHefPNNAMC8efNw11134fnnn8c111yD4uJiPPDAA3C73fj888+D+pm8KtY5fv2fLBSUHsKi/zMIl3Y7K9LDISIiCrtGuUFx8+bN0adPH/Tt27fBizoAuPHGGzFr1iw88cQTuPjii7F27VosX74cnTt3BgAUFxdj9+7dgefffvvtSE5OxosvvojevXtj7NixuPDCC7FkyZIGj8EOhmFg2bJlgTdTkj1qb1JcHcRNitlEJnaRiV3kYROZpHUJait2zJgxmDdvHlq0aIExY8ac8LkNWWD99a9/xV//+td6/2zevHnHPHbffffhvvvuC/nnNCaXy4UWLVoc9yIQCo+4mJq/m1Qb1kmfyyYysYtM7CIPm8gkrUtQC7uEhITAgBMSEmwdkFN4vV5ceeWVkR6G49Xeyy6YjxVjE5nYRSZ2kYdNZJLWJaiF3euvv17vMR2fYRhIT0/H6NGj67x5ksKr9uKJYM7YsYlM7CITu8jDJjJJ6xLye+yqqqpQWVkZ+OcffvgBs2bNwurVq8M6sGjncrnQoUMHMadmnSrOW7Ow04LcimUTedhFJnaRh01kktalQR8pVnuF6oEDB/CrX/0Kzz77LK677ro6n/d6uvN6vRg8ePAxt2ah8PLFhLYVyybysItM7CIPm8gkrUvIC7uNGzdiyJAhAIB33nkHbdu2xQ8//IA333wTzz//fNgHGK10XceCBQtC+gQOCl3tGbtgtmLZRCZ2kYld5GETmaR1CXlhV1lZifj4eADA6tWrMWbMGLjdbgwaNAg//PBD2AcYrTweD3r27Bm4qSHZIy6EM3ZsIhO7yMQu8rCJTNK6hLywO++885Ceno7CwkKsWrUKI0aMAACUlJTwZr9H8Hg86N+/v5jQTuUL4eIJNpGJXWRiF3nYRCZpXUJe2D322GP4+9//ji5duuDSSy/F4MGDAdScvevXr1/YBxitdF1HamqqmFOzThXnrb2P3cnP2LGJTOwiE7vIwyYySesS8jv9/vSnP+GKK65AcXEx+vbtG3j86quvrvN5r6c7j8eDQYMGiVnBO1XtGTvNDO6MHZvIwy4ysYs8bCKTtC4NuoSjbdu2aNu2bZ3HfvWrX4VlQE7h8XjQq1evSA/D8XwhnLFjE5nYRSZ2kYdNZJLWpcGfFUsnpus65syZI+bUrFOFcoNiNpGJXWRiF3nYRCZpXbiws4nX68WIESPE3NfGqUL9SDE2kYddZGIXedhEJmldZIzCgdxuN84777xID8PxQjljxyYysYtM7CIPm8gkrQvP2NlE0zQkJydD07RID8XRAgu7IM7YsYlM7CITu8jDJjJJ68KFnU1iYmIwduxYER8I7GSBrdggztixiUzsIhO7yMMmMknrwq1Ym7jdbnTs2DHSw3C8uMDtTk5+xo5NZGIXmdhFHjaRSVoXnrGziaZpSExMFHNq1qkCHykWxBk7NpGJXWRiF3nYRCZpXVxKKRXpQTS28vJyJCQkoKyszLaPQfP7/SgtLUWrVq3gdnP9bJfv9lXgmllr0bJZLDb+a/gJn8smMrGLTOwiD5vI1BhdQlm3cCvWJm63G61bt470MByv9oxdsFfFsok87CITu8jDJjJJ68Ilv000TcP06dPFnJp1Kp83+PfYsYlM7CITu8jDJjJJ68KtWJu2YpVSqKioQHx8PFwuly0/g4ADlToufiIDAPD90yMR4zn+31XYRCZ2kYld5GETmRqjSyjrFp6xs5HP54v0EByv9qpYILjtWDaRiV1kYhd52EQmSV24sLOJrutISkoS89lxThV7xBm6k23HsolM7CITu8jDJjJJ68KtWBu3YnVdR2xsLE+Z2+yCf66AbvqR/fBV6HBm0+M+j01kYheZ2EUeNpGpMbpwK1YIKW+kdLo4b+2VscFdQEHysItM7CIPm8gkqQsXdjbRdR0zZ84Uc2rWyXyBT5848Xvs2EQmdpGJXeRhE5mkdeFWrE1bsdR4hsz4GIU/VeHdv1yGAZ3PjPRwiIiIwopbsQL4/X6UlJTA7z/59iCdmjhvcGfs2EQmdpGJXeRhE5mkdeHCziaGYSA1NRWGYUR6KI7nC3xe7Il/qdhEJnaRiV3kYROZpHXhViy3YqPen+Z+hi9/+BlXnNcKHc5sEunh2KLb2c1w15BuvBKOiOg0xM+KFcDv96OoqAjt27fnhzXbrFXzmhtDZm8vjfBI7DX0grPRva3z/iLC3xWZ2EUeNpFJWhcu7GxiGAbS0tJwzz33iLojtRP98/c90K/TGTD9Jz75bJomNmzYgEGDBsHrjZ7/9F9ftwulBzX8dFDGFVfhxt8VmdhFHjaRSVoXbsVyK5aEGzNnHTbuPoCXxg3Ab3u3jfRwiIiokfGqWAH8fj+2b98u5ioZit4m8XExAICKahlvzA23aO3idOwiD5vIJK0LF3Y2MU0Tq1evhmmakR4KHRatTeLjaraND2rRNe5gRWsXp2MXedhEJmlduBXLrVgSbuqSr7Dwi0JMGX4BJl99fqSHQ0REjSzqtmLnzJmDrl27Ii4uDgMGDMCnn356wudrmoZHH30UnTt3hs/nw7nnnovXXnutkUYbHMuysGXLFljWiW+aS40nWps4fSs2Wrs4HbvIwyYySesS8YXdokWL8MADD+DRRx/Fpk2bMGTIEIwcORK7d+8+7vfccMMNyMzMRGpqKr777jssXLgQ3bt3b8RRn5xlWdiwYYOY0BS9TeJ9NVuxFdUyTvOHW7R2cTp2kYdNZJLWJeJbsZdeein69++PuXPnBh7r0aMHRo8ejcTExGOev3LlStx0000oKChAy5YtG/QzuRVL0eT1dTsx/f2tuLbPOZh9S/9ID4eIiBpZ1GzF6rqO3NxcjBgxos7jI0aMwGeffVbv9yxbtgwDBw7EjBkz0L59e1xwwQX4+9//jqqqquP+HE3TUF5eXucLQODjP0zTDLzp0TCMeo91XQ+sxo8+rr0SRtO0wHFlZSVyc3NhWRY0TYNSCkqpY46Bmitqjnes6zX3LrMsq95j0zTrzMPOOR19HG1zMgwDGzduRGVlZVTNqYm35tMmKqpNR3aqqqrCl19+GXhtJ8zJCZ0sy8IXX3wReB0nzCnaO1VXVyMnJweWZTlmTk7oZFkWcnJyAq9j15yCFdGFXWlpKSzLQps2beo83qZNG+zbt6/e7ykoKEB2dja++eYbLF26FLNmzcI777yDe+6557g/JzExEQkJCYGvjh07AgAyMjIAAJmZmcjMzAQArFixAtnZ2QCA9PR05OTkAAAWL16MvLw8AMD8+fORn58PAEhJSUFBQQEAYPbs2SgqKgIAPPfcc8jLy4NlWUhKSkJFRQV0XUdSUhJ0XUdFRQWSkpIC/x6Sk5MBAEVFRZg9e3ZgrikpKQCA/Px8zJ8/HwCQl5eHxYsXAwBycnKQnp4OAMjOzsaKFStsm1NycjJKS2s+3SEa57Rjxw5s3boVL730UlTN6avczwHUvMfOiZ0WLFgQWNg5ZU5O6GRZFrKysrB582bHzCnaO61cuRLr16+HZVmOmZMTOlmWhXXr1tk6p9rxBkVFUFFRkQKgPvvsszqPP/XUU+rCCy+s93uGDx+u4uLi1IEDBwKPvfvuu8rlcqnKysp6v6e6ulqVlZUFvgoLCxUAVVpaqpRSyjAMZRiGUkopXdfrPdY0TZmmWe+xZVmBn3O8Y7/fr/x+/zHHSillWdZxjzVNU0opZZpmvceGYShd1+s95pycMaesb4tV54c/UL95Nssxc3JiJ86Jc+KcOCe75lRSUqIAqLKyMnUyEX2Pna7raNq0KdLS0nD99dcHHr///vuxefNmrFmz5pjvmTBhAtatW4ft27cHHvv222/Rs2dPbNu2Deeff/LbQTTGe+xM00ROTg4uueSSqPr4KieL1iZf7ynDqBez0bZFHDb84+pIDyfsorWL07GLPGwiU2N0iZr32MXGxmLAgAGBLdFaGRkZuOyyy+r9nssvvxx79+7FwYMHA49t27YNbrcbHTp0sHW8oVBKYc+ePYjgupmOEq1Nam9Q7NTbnURrF6djF3nYRCZpXSJ+VeyiRYtw22234aWXXsLgwYPxyiuv4NVXX8WWLVvQuXNnTJ06FUVFRXjzzTcBAAcPHkSPHj0waNAgTJ8+HaWlpZg4cSKGDRuGV199NaifyatiKZrsP6hhwFMfAQB2PPM7eNyuCI+IiIgaU9ScsQOAG2+8EbNmzcITTzyBiy++GGvXrsXy5cvRuXNnAEBxcXGde9o1b94cGRkZOHDgAAYOHIhbb70Vo0aNwvPPPx+pKdTLNE1kZWWJ+YgRit4mzeN+ObXvxI8Vi9YuTscu8rCJTNK6iNik/+tf/4q//vWv9f7ZvHnzjnmse/fux2zfSqOUQnl5uZhTsxS9TXxeD2K9buimHxXVBhKaxER6SGEVrV2cjl3kYROZpHWJ+FZsJHArlqLNwKcyUHpQx4r7h6DHOfxvlojodBJVW7FOZZomVq1aJebULEV3k+aHP1bMqVux0drFydhFHjaRSVoXLuyIokB8XM32q1OvjCUiovDgViy3YikK3PLqBny2Yz+eu+liXHdx+0gPh4iIGhG3YgUwDAPLli0LfKYcRV40N/nlXnYyTvWHUzR3cTJ2kYdNZJLWhQs7m7hcLrRo0QIuF+85JkU0N2nuq92Kdd7CLpq7OBm7yMMmMknrwq1YbsVSFJi2bAvmfbYLf73yXDz02+6RHg4RETUibsUKYBgG0tLSxJyapehu0iLOuVfFRnMXJ2MXedhEJmlduLCzicvlQocOHcScmqXobtLcwe+xi+YuTsYu8rCJTNK6iPjkCSfyer0YPHhwpIdBR4jmJk6+3Uk0d3EydpGHTWSS1oVn7Gyi6zoWLFgAXdcjPRQ6LJqb1F4VW+7AM3bR3MXJ2EUeNpFJWhcu7Gzi8XjQs2dPeDyeSA+FDovmJoFPnnDgwi6auzgZu8jDJjJJ68KrYnlVLEWB3B9+xh/nfoaOLZvg04d+HenhEBFRI+JVsQLouo7U1FQxp2Ypupu0cPDFE9HcxcnYRR42kUlaFy7sbOLxeDBo0CAxp2YpupvUXjxxsNqE006yR3MXJ2MXedhEJmlduBXLrViKAgc1E70fXwUA+PaJ36JJrIz/ASEiIvtxK1YAXdcxZ84cMadmKbqbNIv1wH34FklOu+VJNHdxMnaRh01kktaFCzubeL1ejBgxAl4vbxUoRTQ3cblcgStjnXbLk2ju4mTsIg+byCSti4xROJDb7cZ5550X6WHQEaK9SXxcDMqrTcd9rFi0d3EqdpGHTWSS1oVn7GyiaRqSk5OhaVqkh0KHRXuT+MCVsc7aio32Lk7FLvKwiUzSunBhZ5OYmBiMHTsWMTExkR4KHRbtTeIdesuTaO/iVOwiD5vIJK0Lt2Jt4na70bFjx0gPg44Q7U2c+ukT0d7FqdhFHjaRSVoXnrGziaZpSExMFHNqlqK/Se297ModuBUbzV2cil3kYROZpHXhfexsuo+d3+9HaWkpWrVqBbeb62cJor3Jo0u/xluf78b9V5+PB4dfEOnhhE20d3EqdpGHTWRqjC6hrFu4FWsTt9uN1q1bR3oYdIRobxL49AkHXhUbzV2cil3kYROZpHXhkt8mmqZh+vTpYk7NUvQ3cfJVsdHcxanYRR42kUlaF27F2rQVq5RCRUUF4uPj4XK5bPkZFJpob/Lm+l147L0tGNm7LeaOGxDp4YRNtHdxKnaRh01kaowu/EgxIXw+X6SHQEeJ5iZOvd0JEN1dnIxd5GETmSR14cLOJrquIykpScxnx1H0N2nuq3mPXYXD3mMX7V2cil3kYROZpHXhVqyNW7G6riM2NpanzIWI9iYbCvbjplc2oNvZzfDx366M9HDCJtq7OBW7yMMmMjVGF27FCiHljZT0i2hu4uSt2Gju4mTsIg+byCSpCxd2NtF1HTNnzhRzapaiv0n84a1Yp33yRLR3cSp2kYdNZJLWhVuxNm3FEoXbz4d09HsyAwDw/dMjEePh38uIiE4H3IoVwO/3o6SkBH6/P9JDocOivUnzuF/uJ+6ks3bR3sWp2EUeNpFJWhcu7GxiGAZSU1NhGM66mWw0i/YmMR43msR4ADjr0yeivYtTsYs8bCKTtC4itmLnzJmDf//73yguLkavXr0wa9YsDBky5KTft27dOgwbNgy9e/fG5s2bg/553IqlaHXJ0x/hfxUaPpx8BXq1S4j0cIiIqBFE1VbsokWL8MADD+DRRx/Fpk2bMGTIEIwcORK7d+8+4feVlZVh/PjxuPrqqxtppKHx+/0oLCwUc2qWnNHEiVfGOqGLE7GLPGwik7QuEV/YJScn484778TEiRPRo0cPzJo1Cx07dsTcuXNP+H133303brnlFgwePLiRRhoawzCQlpYm5tQsOaNJfNzhmxQ7aGHnhC5OxC7ysIlM0rpEdCtW13U0bdoUaWlpuP766wOP33///di8eTPWrFlT7/e9/vrrmDNnDtavX4+nnnoK6enp3Iql08K4lM+Rvb0UM2/si+v7dYj0cIiIqBFEzVZsaWkpLMtCmzZt6jzepk0b7Nu3r97v+f777/HII4/grbfegtfrrfc5R9M0DeXl5XW+AARW16ZpwjTNwGP1Heu6Dsuy6j2uPf2qaVrguKqqCtu2bYPf74emaVBKQSl1zDGAwHPqO669L45lWfUem6ZZZx52zuno42ibk2ma2L59O6qqqqJ2Ts1ia35lK6pNx3Sqrq4O/K44ZU5O+H3y+/3Iz88PPN8Jc4r2Tpqm4bvvvoPf73fMnJzQye/347vvvgs8x645BSviW7EAjvkIDqVUvR/LYVkWbrnlFkyfPh0XXHBB0K+fmJiIhISEwFfHjh0BABkZNfcEy8zMRGZmJgBgxYoVyM7OBgCkp6cjJycHALB48WLk5eUBAObPn4/8/HwAQEpKCgoKCgAAs2fPRlFREQBg1qxZWLlyJUzTRFJSEioqKup8nlxFRQWSkpIA1Cxwk5OTAQBFRUWYPXs2AKCgoAApKSkAgPz8fMyfPx8AkJeXh8WLFwMAcnJykJ6eDgDIzs7GihUrbJtTcnIySktLASAq57R9+3asXr0ac+fOjdo5/bhnF4CahZ2TOn344YcwTWfNKdp/n0zTxJIlS7Bp0ybHzMkJnZYtWwbTNB01p2jvZJom3nvvPXz00Ue2zal2vEFREaRpmvJ4PGrJkiV1Hp88ebIaOnToMc//+eefFQDl8XgCXy6XK/BYZmZmvT+nurpalZWVBb4KCwsVAFVaWqqUUsowDGUYhlJKKV3X6z3WNE2ZplnvsWVZgZ9zvGO/36/8fv8xx0opZVnWcY81TVNKKWWaZr3HhmEoXdfrPeacnDenx9O/Up0f/kAlLv/WMXNyYifOiXPinDincM6ppKREAVBlZWXqZCJ+u5NLL70UAwYMwJw5cwKP9ezZE9dddx0SExPrPNfv92Pr1q11HpszZw4+/vhjvPPOO+jatSuaNWt20p/ZGO+xsywL+fn56N69Ozwejy0/g0LjhCYzM7bhuczvceulnfD09RdFejhh4YQuTsQu8rCJTI3RJWreYwcAU6ZMQUpKCl577TV8++23ePDBB7F7925MmjQJADB16lSMHz8eAOB2u9G7d+86X61bt0ZcXBx69+4d1KKusViWhQ0bNgT20CnynNDEibc7cUIXJ2IXedhEJmldgrv6wEY33ngj9u/fjyeeeALFxcXo3bs3li9fjs6dOwMAiouLT3pPO4liY2Nx5513RnoYdAQnNGlx+HYnTvrkCSd0cSJ2kYdNZJLWJeJn7ADgr3/9K3bt2gVN05Cbm4uhQ4cG/mzevHnIyso67vdOmzYtpFudNBbLsrBx40YxK3hyRpPmgTN2Mu6XFA5O6OJE7CIPm8gkrYuIhZ0TWZaFrVu3iglNzmji1K3YaO/iROwiD5vIJK1LxC+eiATeoJii1ebCAxg9ex3an9EE6x75daSHQ0REjSCqLp5wKtM0sX79+sCNCSnynNCkuc95W7FO6OJE7CIPm8gkrQsXdjZRSmHPnj04DU+IiuWEJi0Ob8Ue1MyonseRnNDFidhFHjaRSVoXbsVyK5aiSJVuocdjKwEA30y/JnAGj4iInItbsQKYpomsrCwxp2bJGU3iYtzwuGs+bu+gQy6gcEIXJ2IXedhEJmlduLCziVIK5eXlYk7NkjOauFyuI66Mdcb77JzQxYnYRR42kUlaF27FciuWosyQGR+j8KcqvPuXyzCg85mRHg4REdmMW7ECmKaJVatWiTk1S85pEu9z1qdPOKWL07CLPGwik7QuXNgRRRknfvoEERGFB7diuRVLUWbiGzn46NsSJI65CDf/qlOkh0NERDbjVqwAhmFg2bJlMAyeVZHCKU3i42q2Yp1yxs4pXZyGXeRhE5mkdeHCziYulwstWrSAy+WK9FDoMKc0qb13nVNud+KULk7DLvKwiUzSunArlluxFGVmrMzHnKwduP2yLpj2h16RHg4REdmMW7ECGIaBtLQ0MadmyTlNftmKdcYZO6d0cRp2kYdNZJLWhQs7m7hcLnTo0EHMqVlyTpPmgc+LlfE/IqfKKV2chl3kYROZpHXhViy3YinKvLe5CPe/vRmXnXsW/nvXoEgPh4iIbMatWAF0XceCBQug63qkh0KHOaXJLx8p5oytWKd0cRp2kYdNZJLWhQs7m3g8HvTs2RMejyfSQ6HDnNKk9j12TvnkCad0cRp2kYdNZJLWhVux3IqlKPNtcTlGPvcpWjWPxZf/HB7p4RARkc24FSuArutITU0Vc2qWnNOkdiu23EFbsU7o4jTsIg+byCStCxd2NvF4PBg0aJCYU7PknCa1W7G66YdmWhEezalzShenYRd52EQmaV24FcutWIoyll/h3H8sBwDk/vM3OKu5L8IjIiIiO3ErVgBd1zFnzhwxp2bJOU08bheaxdb8zdAJV8Y6pYvTsIs8bCKTtC7eSA/AqbxeL0aMGAGvl/+KpXBSk/i4GBzSLXz3YwWi/ZS73+9Hz0uvROEBDW63M2667ATsIo+0JjEeF9qf0UTMjXkjRdr/t3ArlluxFIV+k7wG20sORnoYRHSam3z1+Zgy/IJID8PxQlm3yFheOpCmaZg9ezbuuece+Hx8D5QETmrypwEdMDdrB/wO+XuZpmlR38SJ2EUeKU0sv0KlbmH518Wn/cJO2v+38IydTWfs/H4/ioqK0L59e7jdfCujBGwiE7vIxC7ySGpyoFJHvyczoBSQ8+hvcHZ85Bc0kdIYXXjxhAButxsdO3aM+C8f/YJNZGIXmdhFHklNzmgai+5taxYYn+/cH+HRRJakLgAXdrbRNA2JiYnQNC3SQ6HD2EQmdpGJXeSR1mRQt5YAgA0Fp/fCTloXbsXauBVbWlqKVq1aiVnFn+7YRCZ2kYld5JHWZNWWfbh7fi7Oa90cH00ZFunhRExjdOFWrAButxutW7cW8ctHNdhEJnaRiV3kkdbk0q4t4XIB20sO4n8VMs5WRYK0LjJG4UCapmH69OliTs0Sm0jFLjKxizzSmvB9djWkdeFWrE1bsUopVFRUID4+/rS/eaMUbCITu8jELvJIbDL9/S14fd0ujBvUCU+NvijSw4mIxujCrVghJNzPhupiE5nYRSZ2kUdak0HdzgIAbCj4KcIjiSxJXbiws4mu60hKShLz2XHEJlKxi0zsIo/EJnyfnbwuIrZi58yZg3//+98oLi5Gr169MGvWLAwZMqTe5y5ZsgRz587F5s2boWkaevXqhWnTpuGaa64J+uc11lasruuIjY0Vc8r8dMcmMrGLTOwij9QmI5/7FN8Wl+PFW/rh933aRXo4ja4xukTVVuyiRYvwwAMP4NFHH8WmTZswZMgQjBw5Ert37673+WvXrsXw4cOxfPly5Obm4qqrrsKoUaOwadOmRh75yUl5IyX9gk1kYheZ2EUeiU14PztZXSK+sEtOTsadd96JiRMnokePHpg1axY6duyIuXPn1vv8WbNm4aGHHsIll1yC888/H8888wzOP/98vP/++4088hPTdR0zZ84Uc2qW2EQqdpGJXeSR2uR0f5+dtC4R3YrVdR1NmzZFWloarr/++sDj999/PzZv3ow1a9ac9DX8fj+6dOmChx56CPfee29QP7cxtmKJiIhOB/zcWPtFzVZsaWkpLMtCmzZt6jzepk0b7Nu3L6jXePbZZ3Ho0CHccMMNx32OpmkoLy+v8wUAhmEAAEzThGmagcfqO9Z1HZZl1Xvs9/sDP6f2uKqqCvv27YPf74emaVBKQSl1zDGAwHPqO679G4BlWfUem6ZZZx52zuno42ibk2maKCkpQVVVlWPm5IRO1dXVKC4uDvxMJ8zJCZ1qP9i89vlOmFO0d9I0LfC7ImlO8T4PLmzTHACwfsf/TrtOfr8fe/fuDTzHrjkFK+JbsQCOebOhUiqoNyAuXLgQ06ZNw6JFi9C6devjPi8xMREJCQmBr44dOwIAMjIyAACZmZnIzMwEAKxYsQLZ2dkAgPT0dOTk5AAAFi9ejLy8PADA/PnzkZ+fDwBISUlBQUEBAGD27NkoKioCULNlnJqaCsMwkJSUhIqKijpXzlRUVCApKQlAzQI3OTkZAFBUVITZs2cDAAoKCpCSkgIAyM/Px/z58wEAeXl5WLx4MQAgJycH6enpAIDs7GysWLHCtjklJyejtLQUAKJyTt9//z1SU1Mxd+5cx8zJKZ1ee+01GIbhqDlFeyfDMJCamhp4/7IT5hTtnZYvX46UlBQYhiFuTi2qf6wZY873p12n2t+Vjz76yLY51Y43KCqCNE1THo9HLVmypM7jkydPVkOHDj3h97799tuqSZMm6oMPPjjpz6murlZlZWWBr8LCQgVAlZaWKqWUMgxDGYahlFJK1/V6jzVNU6Zp1ntsWVbg5xzv2O/3K7/ff8yxUkpZlnXcY03TlFJKmaZZ77FhGErX9XqPOSfOiXPinDgnzqkx5vT+pkLV+eEP1G+ezXLMnCR1KikpUQBUWVmZOpmI3+7k0ksvxYABAzBnzpzAYz179sR1112HxMTEer9n4cKFuOOOO7Bw4UKMHj065J/ZGO+xq93GaN++vZjPjzvdsYlM7CITu8gjucnPh2reZwcAX/7zN2jV/PR5n11jdIma99gBwJQpU5CSkoLXXnsN3377LR588EHs3r0bkyZNAgBMnToV48ePDzx/4cKFGD9+PJ599lkMGjQI+/btw759+1BWVhapKdTLMAykpaUF9uIp8thEJnaRiV3kkdzkzGax6N42HgDw+Wl2day0LhE/YwfU3KB4xowZKC4uRu/evTFz5kwMHToUAHD77bdj165dyMrKAgBceeWV9V4tO2HCBMybNy+on8erYomIiMJr2rItmPfZLpwd78PZp9EZOwAYesHZeGRkd9teP5R1i4iFXWNrrK3YgoICdOvWTdwp89MVm8jELjKxizzSm2R/X4pxqZ9HehgRcWW3eLw28QoRW7FeW0ZAME0Tq1evxsSJExEbGxvp4RDYRCp2kYld5JHe5IrzW+GD+67A/kMybtTbWEzDwKcZH8I0B4nowjN23IolIiIiwaLq4gmnsiwLW7ZsCdyAkCKPTWRiF5nYRR42kUlaFy7sbGJZFjZs2CAmNLGJVOwiE7vIwyYySevCrVhuxRIREZFg3IoVwLIsbNy4UcwKnthEKnaRiV3kYROZpHXhws4mlmVh69atYkITm0jFLjKxizxsIpO0LtyK5VYsERERCcatWAFM08T69ethmmakh0KHsYlM7CITu8jDJjJJ68KFnU2UUtizZw9OwxOiYrGJTOwiE7vIwyYySevCrVhuxRIREZFg3IoVwDRNZGVliTk1S2wiFbvIxC7ysIlM0rpwYWcTpRTKy8vFnJolNpGKXWRiF3nYRCZpXbgVy61YIiIiEoxbsQKYpolVq1aJOTVLbCIVu8jELvKwiUzSunBhR0REROQQ3IrlViwREREJFsq6xdtIYxKldi1bXl5u288wDAMZGRkYPnw4YmJibPs5FDw2kYldZGIXedhEpsboUrteCeZc3Gm5sKuoqAAAdOzYMcIjISIiIgpORUUFEhISTvic03Ir1u/3Y+/evYiPj4fL5bLlZ5SXl6Njx44oLCzkdq8QbCITu8jELvKwiUyN0UUphYqKCrRr1w5u94kvjzgtz9i53W506NChUX5WixYt+AsoDJvIxC4ysYs8bCKT3V1OdqauFq+KJSIiInIILuyIiIiIHIILO5v4fD48/vjj8Pl8kR4KHcYmMrGLTOwiD5vIJK3LaXnxBBEREZET8YwdERERkUNwYUdERETkEFzYERERETkEF3Y2mDNnDrp27Yq4uDgMGDAAn376aaSHdFpJTEzEJZdcgvj4eLRu3RqjR4/Gd999V+c5SilMmzYN7dq1Q5MmTXDllVdiy5YtERrx6ScxMREulwsPPPBA4DE2iYyioiKMGzcOZ511Fpo2bYqLL74Yubm5gT9nl8Zlmib++c9/omvXrmjSpAm6deuGJ554An6/P/AcNrHf2rVrMWrUKLRr1w4ulwvp6el1/jyYBpqm4b777kOrVq3QrFkz/OEPf8CePXvsH7yisHr77bdVTEyMevXVV9XWrVvV/fffr5o1a6Z++OGHSA/ttHHNNdeo119/XX3zzTdq8+bN6tprr1WdOnVSBw8eDDwnKSlJxcfHq3fffVd9/fXX6sYbb1TnnHOOKi8vj+DITw9ffPGF6tKli+rTp4+6//77A4+zSeP76aefVOfOndXtt9+uPv/8c7Vz50710Ucfqe3btweewy6N66mnnlJnnXWW+uCDD9TOnTtVWlqaat68uZo1a1bgOWxiv+XLl6tHH31UvfvuuwqAWrp0aZ0/D6bBpEmTVPv27VVGRobauHGjuuqqq1Tfvn2VaZq2jp0LuzD71a9+pSZNmlTnse7du6tHHnkkQiOikpISBUCtWbNGKaWU3+9Xbdu2VUlJSYHnVFdXq4SEBPXSSy9FapinhYqKCnX++eerjIwMNWzYsMDCjk0i4+GHH1ZXXHHFcf+cXRrftddeq+644446j40ZM0aNGzdOKcUmkXD0wi6YBgcOHFAxMTHq7bffDjynqKhIud1utXLlSlvHy63YMNJ1Hbm5uRgxYkSdx0eMGIHPPvssQqOisrIyAEDLli0BADt37sS+ffvqdPL5fBg2bBg72eyee+7Btddei9/85jd1HmeTyFi2bBkGDhyIsWPHonXr1ujXrx9effXVwJ+zS+O74oorkJmZiW3btgEA8vLykJ2djd/97ncA2ESCYBrk5ubCMIw6z2nXrh169+5te6fT8rNi7VJaWgrLstCmTZs6j7dp0wb79u2L0KhOb0opTJkyBVdccQV69+4NAIEW9XX64YcfGn2Mp4u3334bGzduRE5OzjF/xiaRUVBQgLlz52LKlCn4xz/+gS+++AKTJ0+Gz+fD+PHj2SUCHn74YZSVlaF79+7weDywLAtPP/00br75ZgD8XZEgmAb79u1DbGwszjzzzGOeY/d6gAs7G7hcrjr/rJQ65jFqHPfeey+++uorZGdnH/Nn7NR4CgsLcf/992P16tWIi4s77vPYpHH5/X4MHDgQzzzzDACgX79+2LJlC+bOnYvx48cHnscujWfRokVYsGAB/vvf/6JXr17YvHkzHnjgAbRr1w4TJkwIPI9NIq8hDRqjE7diw6hVq1bweDzHrMZLSkqOWdmT/e677z4sW7YMn3zyCTp06BB4vG3btgDATo0oNzcXJSUlGDBgALxeL7xeL9asWYPnn38eXq838O+dTRrXOeecg549e9Z5rEePHti9ezcA/q5Ewv/9v/8XjzzyCG666SZcdNFFuO222/Dggw8iMTERAJtIEEyDtm3bQtd1/Pzzz8d9jl24sAuj2NhYDBgwABkZGXUez8jIwGWXXRahUZ1+lFK49957sWTJEnz88cfo2rVrnT/v2rUr2rZtW6eTrutYs2YNO9nk6quvxtdff43NmzcHvgYOHIhbb70VmzdvRrdu3dgkAi6//PJjbgW0bds2dO7cGQB/VyKhsrISbnfd/2v2eDyB252wSeQF02DAgAGIiYmp85zi4mJ888039ney9dKM01Dt7U5SU1PV1q1b1QMPPKCaNWumdu3aFemhnTb+8pe/qISEBJWVlaWKi4sDX5WVlYHnJCUlqYSEBLVkyRL19ddfq5tvvpm3C2hkR14VqxSbRMIXX3yhvF6vevrpp9X333+v3nrrLdW0aVO1YMGCwHPYpXFNmDBBtW/fPnC7kyVLlqhWrVqphx56KPAcNrFfRUWF2rRpk9q0aZMCoJKTk9WmTZsCty4LpsGkSZNUhw4d1EcffaQ2btyofv3rX/N2J9Fq9uzZqnPnzio2Nlb1798/cJsNahwA6v16/fXXA8/x+/3q8ccfV23btlU+n08NHTpUff3115Eb9Gno6IUdm0TG+++/r3r37q18Pp/q3r27euWVV+r8Obs0rvLycnX//ferTp06qbi4ONWtWzf16KOPKk3TAs9hE/t98skn9f7/yIQJE5RSwTWoqqpS9957r2rZsqVq0qSJ+v3vf692795t+9hdSill7zlBIiIiImoMfI8dERERkUNwYUdERETkEFzYERERETkEF3ZEREREDsGFHREREZFDcGFHRERE5BBc2BERERE5BBd2RERERA7BhR0RERGRQ3BhR0RUj5KSEtx9993o1KkTfD4f2rZti2uuuQbr168HALhcLqSnp0d2kERER/FGegBERBL98Y9/hGEYeOONN9CtWzf8+OOPyMzMxE8//RTpoRERHRc/K5aI6CgHDhzAmWeeiaysLAwbNuyYP+/SpQt++OGHwD937twZu3btAgC8//77mDZtGrZs2YJ27dphwoQJePTRR+H11vw92uVyYc6cOVi2bBmysrLQtm1bzJgxA2PHjm2UuRGRs3ErlojoKM2bN0fz5s2Rnp4OTdOO+fOcnBwAwOuvv47i4uLAP69atQrjxo3D5MmTsXXrVrz88suYN28enn766Trf/69//Qt//OMfkZeXh3HjxuHmm2/Gt99+a//EiMjxeMaOiKge7777Lu666y5UVVWhf//+GDZsGG666Sb06dMHQM2Zt6VLl2L06NGB7xk6dChGjhyJqVOnBh5bsGABHnroIezduzfwfZMmTcLcuXMDzxk0aBD69++POXPmNM7kiMixeMaOiKgef/zjH7F3714sW7YM11xzDbKystC/f3/MmzfvuN+Tm5uLJ554InDGr3nz5rjrrrtQXFyMysrKwPMGDx5c5/sGDx7MM3ZEFBa8eIKI6Dji4uIwfPhwDB8+HI899hgmTpyIxx9/HLfffnu9z/f7/Zg+fTrGjBlT72udiMvlCseQieg0xzN2RERB6tmzJw4dOgQAiImJgWVZdf68f//++O6773Deeecd8+V2//I/txs2bKjzfRs2bED37t3tnwAROR7P2BERHWX//v0YO3Ys7rjjDvTp0wfx8fH48ssvMWPGDFx33XUAaq6MzczMxOWXXw6fz4czzzwTjz32GH7/+9+jY8eOGDt2LNxuN7766it8/fXXeOqppwKvn5aWhoEDB+KKK67AW2+9hS+++AKpqamRmi4ROQgvniAiOoqmaZg2bRpWr16NHTt2wDCMwGLtH//4B5o0aYL3338fU6ZMwa5du9C+ffvA7U5WrVqFJ554Aps2bUJMTAy6d++OiRMn4q677gJQs+U6e/ZspKenY+3atWjbti2SkpJw0003RXDGROQUXNgRETWi+q6mJSIKF77HjoiIiMghuLAjIiIicghePEFE1Ij47hcishPP2BERERE5BBd2RERERA7BhR0RERGRQ3BhR0REROQQXNgREREROQQXdkREREQOwYUdERERkUNwYUdERETkEFzYERERETnE/wet5t79vY5zugAAAABJRU5ErkJggg==",
+      "text/plain": [
+       "<Figure size 640x480 with 1 Axes>"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "# plot optimization performance\n",
+    "fig, ax = plt.subplots()\n",
+    "ax.plot(torch.arange(n_step + 1), utils.get_running_optimum(X.data, X.vocs.objective_names[0], maximize=False)[n_init - 1:])\n",
+    "ax.set_xlabel(\"Step\")\n",
+    "ax.set_ylabel(f\"{vocs.objective_names[0]} (mm)\")\n",
+    "ax.grid(color=\"gray\", linestyle=\":\")\n",
+    "fig.tight_layout()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Calibration Results"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 12,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/html": [
+       "<div>\n",
+       "<style scoped>\n",
+       "    .dataframe tbody tr th:only-of-type {\n",
+       "        vertical-align: middle;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe tbody tr th {\n",
+       "        vertical-align: top;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe thead th {\n",
+       "        text-align: right;\n",
+       "    }\n",
+       "</style>\n",
+       "<table border=\"1\" class=\"dataframe\">\n",
+       "  <thead>\n",
+       "    <tr style=\"text-align: right;\">\n",
+       "      <th></th>\n",
+       "      <th>x_offset</th>\n",
+       "      <th>x_offset_learned</th>\n",
+       "      <th>x_scale</th>\n",
+       "      <th>x_scale_learned</th>\n",
+       "    </tr>\n",
+       "  </thead>\n",
+       "  <tbody>\n",
+       "    <tr>\n",
+       "      <th>0</th>\n",
+       "      <td>0.148877</td>\n",
+       "      <td>0.147580</td>\n",
+       "      <td>1.050658</td>\n",
+       "      <td>1.545765</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>1</th>\n",
+       "      <td>0.230467</td>\n",
+       "      <td>0.056188</td>\n",
+       "      <td>1.088166</td>\n",
+       "      <td>2.117664</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>2</th>\n",
+       "      <td>0.026543</td>\n",
+       "      <td>0.036432</td>\n",
+       "      <td>1.155557</td>\n",
+       "      <td>1.687181</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>3</th>\n",
+       "      <td>0.039609</td>\n",
+       "      <td>0.318036</td>\n",
+       "      <td>1.209300</td>\n",
+       "      <td>9.992797</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>4</th>\n",
+       "      <td>0.092227</td>\n",
+       "      <td>0.633975</td>\n",
+       "      <td>1.240003</td>\n",
+       "      <td>3.901057</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>5</th>\n",
+       "      <td>0.190224</td>\n",
+       "      <td>0.653803</td>\n",
+       "      <td>1.048309</td>\n",
+       "      <td>1.306098</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>6</th>\n",
+       "      <td>0.147028</td>\n",
+       "      <td>-0.136846</td>\n",
+       "      <td>1.084681</td>\n",
+       "      <td>0.709849</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>7</th>\n",
+       "      <td>0.268933</td>\n",
+       "      <td>-0.773065</td>\n",
+       "      <td>1.204483</td>\n",
+       "      <td>0.706172</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>8</th>\n",
+       "      <td>0.136688</td>\n",
+       "      <td>-0.419964</td>\n",
+       "      <td>1.274558</td>\n",
+       "      <td>1.078321</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>9</th>\n",
+       "      <td>0.189692</td>\n",
+       "      <td>0.200885</td>\n",
+       "      <td>1.119130</td>\n",
+       "      <td>1.434628</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>10</th>\n",
+       "      <td>0.104668</td>\n",
+       "      <td>0.385939</td>\n",
+       "      <td>1.262247</td>\n",
+       "      <td>2.567048</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>11</th>\n",
+       "      <td>0.120515</td>\n",
+       "      <td>0.979201</td>\n",
+       "      <td>1.125823</td>\n",
+       "      <td>2.578461</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>12</th>\n",
+       "      <td>0.006698</td>\n",
+       "      <td>-0.530888</td>\n",
+       "      <td>1.165872</td>\n",
+       "      <td>0.442888</td>\n",
+       "    </tr>\n",
+       "  </tbody>\n",
+       "</table>\n",
+       "</div>"
+      ],
+      "text/plain": [
+       "    x_offset  x_offset_learned   x_scale  x_scale_learned\n",
+       "0   0.148877          0.147580  1.050658         1.545765\n",
+       "1   0.230467          0.056188  1.088166         2.117664\n",
+       "2   0.026543          0.036432  1.155557         1.687181\n",
+       "3   0.039609          0.318036  1.209300         9.992797\n",
+       "4   0.092227          0.633975  1.240003         3.901057\n",
+       "5   0.190224          0.653803  1.048309         1.306098\n",
+       "6   0.147028         -0.136846  1.084681         0.709849\n",
+       "7   0.268933         -0.773065  1.204483         0.706172\n",
+       "8   0.136688         -0.419964  1.274558         1.078321\n",
+       "9   0.189692          0.200885  1.119130         1.434628\n",
+       "10  0.104668          0.385939  1.262247         2.567048\n",
+       "11  0.120515          0.979201  1.125823         2.578461\n",
+       "12  0.006698         -0.530888  1.165872         0.442888"
+      ]
+     },
+     "execution_count": 12,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "# evaluate input calibration\n",
+    "learned_custom_mean = X.generator.model.models[0].mean_module._model\n",
+    "df = pd.DataFrame(columns=[\"x_offset\", \"x_offset_learned\", \"x_scale\", \"x_scale_learned\"])\n",
+    "for i in range(x_size):\n",
+    "    x_offset = miscalibrated_objective_model.x_offset.detach()[i].item()\n",
+    "    x_offset_learned = -learned_custom_mean.x_offset.detach()[i].item()\n",
+    "    x_scale = miscalibrated_objective_model.x_scale.detach()[i].item()\n",
+    "    x_scale_learned = 1 / learned_custom_mean.x_scale.detach()[i].item()\n",
+    "    df.loc[len(df.index)] = [x_offset, x_offset_learned, x_scale, x_scale_learned]\n",
+    "df"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 13,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/html": [
+       "<div>\n",
+       "<style scoped>\n",
+       "    .dataframe tbody tr th:only-of-type {\n",
+       "        vertical-align: middle;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe tbody tr th {\n",
+       "        vertical-align: top;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe thead th {\n",
+       "        text-align: right;\n",
+       "    }\n",
+       "</style>\n",
+       "<table border=\"1\" class=\"dataframe\">\n",
+       "  <thead>\n",
+       "    <tr style=\"text-align: right;\">\n",
+       "      <th></th>\n",
+       "      <th>y_offset</th>\n",
+       "      <th>y_offset_learned</th>\n",
+       "      <th>y_scale</th>\n",
+       "      <th>y_scale_learned</th>\n",
+       "    </tr>\n",
+       "  </thead>\n",
+       "  <tbody>\n",
+       "    <tr>\n",
+       "      <th>0</th>\n",
+       "      <td>0.285821</td>\n",
+       "      <td>0.810209</td>\n",
+       "      <td>1.010849</td>\n",
+       "      <td>1.456044</td>\n",
+       "    </tr>\n",
+       "  </tbody>\n",
+       "</table>\n",
+       "</div>"
+      ],
+      "text/plain": [
+       "   y_offset  y_offset_learned   y_scale  y_scale_learned\n",
+       "0  0.285821          0.810209  1.010849         1.456044"
+      ]
+     },
+     "execution_count": 13,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "# evaluate output calibration\n",
+    "learned_custom_mean = X.generator.model.models[0].mean_module._model\n",
+    "df = pd.DataFrame(columns=[\"y_offset\", \"y_offset_learned\", \"y_scale\", \"y_scale_learned\"])\n",
+    "for i in range(y_size):\n",
+    "    y_offset = miscalibrated_objective_model.y_offset.detach()[i].item()\n",
+    "    y_offset_learned = -learned_custom_mean.y_offset.detach()[i].item()\n",
+    "    y_scale = miscalibrated_objective_model.y_scale.detach()[i].item()\n",
+    "    y_scale_learned = 1 / learned_custom_mean.y_scale.detach()[i].item()\n",
+    "    df.loc[len(df.index)] = [y_offset, y_offset_learned, y_scale, y_scale_learned]\n",
+    "df"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Backprop Approach"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Create Trainable Model and Data Set"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 14,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "[Parameter containing:\n",
+       " tensor([0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0.],\n",
+       "        requires_grad=True),\n",
+       " Parameter containing:\n",
+       " tensor([0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0.],\n",
+       "        requires_grad=True),\n",
+       " Parameter containing:\n",
+       " tensor([0.], requires_grad=True),\n",
+       " Parameter containing:\n",
+       " tensor([0.], requires_grad=True)]"
+      ]
+     },
+     "execution_count": 14,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "# create calibrated model\n",
+    "cal_model = DecoupledLinear(\n",
+    "    model=miscalibrated_objective_model,\n",
+    "    x_size=x_size,\n",
+    "    y_size=y_size,\n",
+    ")\n",
+    "cal_model.to(device)\n",
+    "\n",
+    "# define trainable parameters\n",
+    "trainable_params = cal_model.raw_calibration_parameters\n",
+    "trainable_params"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 15,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# create data set\n",
+    "x = torch.tensor(\n",
+    "    X.data[vocs.variable_names].values,\n",
+    "    dtype=torch.double,\n",
+    "    device=device,\n",
+    ")\n",
+    "pred = torch.tensor(\n",
+    "    X.data[vocs.output_names].values,\n",
+    "    dtype=torch.double,\n",
+    "    device=device,\n",
+    ").squeeze()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 16,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# define data set class\n",
+    "class Dataset(torch.utils.data.Dataset):\n",
+    "    def __init__(self, x, y):\n",
+    "        self.x, self.y = x, y\n",
+    "\n",
+    "    def __len__(self):\n",
+    "        return self.y.shape[0]\n",
+    "\n",
+    "    def __getitem__(self, idx):\n",
+    "        x, y = self.x[idx], self.y[idx]\n",
+    "        return x, y\n",
+    "\n",
+    "\n",
+    "# define dataloader\n",
+    "trainloader = torch.utils.data.DataLoader(\n",
+    "    dataset=Dataset(x, pred),\n",
+    "    batch_size=pred.shape[0],\n",
+    "    shuffle=True,\n",
+    "    num_workers=0,\n",
+    "    pin_memory=not \"cuda\" in device,  # we can't use this if we're on the GPU\n",
+    ")\n",
+    "\n",
+    "# define optimizer and loss function\n",
+    "optimizer = torch.optim.Adam(\n",
+    "    params=trainable_params,\n",
+    "    lr=1e-3,\n",
+    "    weight_decay=1e-3,  # regularization favors conservative calibration\n",
+    ")\n",
+    "criterion = torch.nn.L1Loss()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Training Loop"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 17,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "CPU times: user 3min 15s, sys: 42.8 s, total: 3min 58s\n",
+      "Wall time: 2min 18s\n"
+     ]
+    }
+   ],
+   "source": [
+    "%%time\n",
+    "# training loop\n",
+    "losses = []\n",
+    "n_epochs = int(1e4)\n",
+    "for epoch in range(n_epochs):\n",
+    "    for i, batch_data in enumerate(trainloader, 0):\n",
+    "        inputs, targets = batch_data\n",
+    "        optimizer.zero_grad()\n",
+    "        outputs = cal_model(inputs)\n",
+    "        loss = criterion(outputs, targets)\n",
+    "        loss.backward()\n",
+    "        optimizer.step()\n",
+    "        if i == 0:\n",
+    "            losses.append(loss.item())"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 18,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "image/png": "iVBORw0KGgoAAAANSUhEUgAAAkwAAAGFCAYAAAAPa6wiAAAAOXRFWHRTb2Z0d2FyZQBNYXRwbG90bGliIHZlcnNpb24zLjkuMiwgaHR0cHM6Ly9tYXRwbG90bGliLm9yZy8hTgPZAAAACXBIWXMAAA9hAAAPYQGoP6dpAABwlklEQVR4nO3dd3wUdf4/8NdsDSnEhIQSOglFWgwBlRpQFCIXDht4AqKCHhCV8vUQ1FPAkpyewPkzYMEOp2DjQFCMhVCVGgRD7yWQECChZev8/ohZstndbMruZyab1/Px8PEws7Mzn3nNsnln5vP5jCTLsgwiIiIi8kijdAOIiIiI1I4FExEREZEXLJiIiIiIvGDBREREROQFCyYiIiIiL1gwEREREXnBgomIiIjICxZMRERERF6wYCIiIiLyggUTERERkRcsmIiIiIi8CPiC6cSJE+jfvz86duyIrl274osvvlC6SURERFTLSIH+8N3c3FycPXsWN910E/Ly8tCtWzfs27cPISEhlXq/3W7H6dOnERYWBkmS/NxaIiIiEkmWZVy6dAkxMTHQaDxfR9IJbJMimjRpgiZNmgAAGjZsiMjISJw/f77SBdPp06fRvHlzfzaRiIiIFHbixAk0a9bM4+uqL5jWrl2L119/Hdu2bUNubi6++eYbDBs2zGmd+fPn4/XXX0dubi46deqEefPmoW/fvi7b2rp1K+x2e5UKoLCwMAAlQdavX79Gx1KeyWTCnDlzMHXqVBiNRp9um1wxb7GYt1jMWyzmLZY/8y4qKkLz5s0dv+89UX3BdOXKFcTHx+ORRx7Bvffe6/L6kiVLMHnyZMyfPx+9e/fGO++8g+TkZOTk5KBFixaO9QoKCvDQQw9h4cKFFe7PZDLBZDI5fr506RIAwGg0Ok6SRqOBXq+HxWKB3W53rKvVaqHT6WA2m1H2TqdOp4NWq3VZrtfrERQU5LTt0uWSJMFsNju1zWAwQJZlWCwWp+VGoxF2u91puSRJMBgMsNlssFqtLsutVitsNptjuS+PSaPROGWopmMKCgpCcHAwQkJCAuaYAHWep6tXrzp9vgPhmNR+noKCghAaGupyW6E2H5Naz1Np3kaj0ZF5bT8mNZ8no9Ho8vvSV8cUGhrq2H9FVF8wJScnIzk52ePrc+bMwdixYzFu3DgAwLx587B69WosWLAAaWlpAEqKoLvvvhszZsxAr169KtxfWloaZs2a5XY/QUFBAICEhAQMHToU3333HXbs2OFYJykpCf3798fSpUtx6NAhx/KUlBR069YNCxcuRH5+vmP58OHDAQAZGRlOH74JEyYgPDwc6enpTm2YPn06CgsLsWDBAscyg8GAGTNm4PDhw1i8eLFjeXR0NCZOnIidO3dixYoVjuWxsbEYNWoU1q9fj6ysLMdyXx3TyJEjERcXhzlz5qj2mDZt2oSBAwcG1DGp8Tzt3r0bADB37tyAOSa1nyeg5I/D999/P2COSe3nae7cuQF3TID6ztOgQYMcefv6mEaNGoXKqFWdviVJcrolZzabERwcjC+++AJ33323Y71JkyYhOzsbWVlZkGUZDz74INq3b4+ZM2d63Uf5K0yll+ry8vIct+R8VcFLkoSNGzeiR48e0Omu1678q8Q/x2S1WrFp0yb06dMHQUFBAXFMpdR4nkwmE9atW4eePXtCp9MFxDGp+TxZrVZs3rwZvXv3Rvmv9dp6TIB6z5PFYsGmTZvQs2dP1KtXLyCOSc3nSZIkZGVl4dZbb3X8vvTVMV27dg0REREoLCyssOtNrS6YTp8+jaZNm2LDhg1OV45effVVfPzxx9i3bx/Wr1+Pfv36oWvXro7XP/30U3Tp0qVS+ywqKkJ4eLjXIImIiKj2qezv+YCYh6n8fUdZlh3L+vTpA7vdjuzsbMd/lSmWMjIy0LFjR/To0cMvbQZKrpAtWrTIpVIn/2DeYjFvsZi3WMxbLDXkXasLpqioKGi1Wpw5c8ZpeV5eHho1alSjbaempiInJwdbtmyp0XYqIssyDh065HL5nPyDeYvFvMVi3mIxb7HUkHetLpgMBgMSExORmZnptDwzM9Nr524iIiKiylL9KLnLly/j4MGDjp+PHDmC7OxsREZGokWLFpg6dSpGjx6N7t27o2fPnnj33Xdx/PhxjB8/vkb7zcjIQEZGhlPHMyIiIqqbVN/pe82aNRgwYIDL8jFjxuCjjz4CUDJx5WuvvYbc3Fx07twZc+fORb9+/Xyyf392+rbZbNi5cyfi4+Oh1Wp9um1yxbzFYt5iMW+xmLdY/sy7sr/nVV8wKY2j5IiIiAJXnRol5w+iRsnNnz+foywEYd5iMW+xmLdYzFssNeTNgskDf4+Su1RswZaj57H37GWOshBElmXk5+czb0GYt1jMWyzmLZYa8lZ9p+9A9cH6o5j7437Eams2/QERERH5H68wKeTGJiVPRb5gD1a4JUREROQNCyaF3NikpGNZkRQMWeIICxH0ej1GjhwJvV6vdFPqBOYtFvMWi3mLpYa8WTB54O9O380i6iEsSAerHTh87qpf9kHONBoN4uLioNHwYy8C8xaLeYvFvMVSQ9480x74u9O3JEno0CgUALDrRIFf9kHOTCYT0tLSXJ5UTf7BvMVi3mIxb7HUkDcLJgV1aFzSj2nPmcsKt6Tu4BBgsZi3WMxbLOYtltJ5s2BSUIfGJVeY9p65pHBLiIiIqCIsmDwQMXFl24YlBdORAvZhIiIiUjM+GsULfz4a5fzlYnR7+ScAwB+zBiHEyGmx/Mlut+PcuXOIiopiR00BmLdYzFss5i2WP/Pmo1FqgYgQIyKCS4ZIHi24onBrAp8kSQgPD4ckSUo3pU5g3mIxb7GYt1hqyJsFk4LMZjP0xRcAAEfOsWDyN7PZjPT0dMU7DtYVzFss5i0W8xZLDXmzYFJYfakYAHAknwUTERGRWrFgUlh4acHEK0xERESqxYLJAxGj5ACgvqakYDrMgomIiEi1OErOC3+OkpNlGTuOnsM972xGdJgRW54b6NPtkzNZlmE2m2EwGNhRUwDmLRbzFot5i+XPvDlKrhaQZRmhmpIObPmXTDBZbQq3KLDJsozCwkLwbwQxmLdYzFss5i2WGvJmwaQgi8WC/364EPX0Jach92Kxwi0KbBaLBQsWLIDFYlG6KXUC8xaLeYvFvMVSQ94smBQmSUCT8CAAwOmL1xRuDREREbnDgkkFYm6oBwA4yYKJiIhIlVgwKcxgMCDmzytMpy6wYPI3g8GgdBPqFOYtFvMWi3mLpXTeHCXnhT9HyZV66+cD+PcP+3F/YjO8fn+8X/ZBRERErjhKroZEzMNkt9tx8OBBNK5fcoUpt5Cdvv2pNG+73a50U+oE5i0W8xaLeYulhrxZMHmQmpqKnJwcbNmyxW/7sFgsWLx4MSKDtQBKphYg/ynNm6NaxGDeYjFvsZi3WGrImwWTCkSHGgEAeZd4hYmIiEiNWDCpQFRoSUe2C1ctMFt5eZeIiEhtWDApSJIkREdHIyLYAL22ZKr3c5d5W85fSvPmYwzEYN5iMW+xmLdYasibo+S8EDFKDgB6pv2E3MJiLEvtjZua3+C3/RAREdF1HCVXC9hsNmzfvh02mw0Nw0r6MbHjt/+UzZv8j3mLxbzFYt5iqSFvFkwKslqtWLFiBaxWK6LD2PHb38rmTf7HvMVi3mIxb7HUkDcLJpWIDiuZi4lXmIiIiNSHBZNKXL/CxIKJiIhIbVgwKUiSJMTGxkKSJEcfprwiFkz+UjZv8j/mLRbzFot5i6WGvDlKzoOMjAxkZGTAZrNh//79fh8l9/3uXIxftB2JLSPw1YReftsPERERXcdRcjUk4tEoVqsVa9asgdVqxQ3Bf05eecXst/3VdWXzJv9j3mIxb7GYt1hqyJsFk4JsNhuysrJgs9kQGVJSMJ2/yoLJX8rmTf7HvMVi3mIxb7HUkDcLJpWI+PMKU+E1C2x23iUlIiJSExZMKnFDsB4AIMslRRMRERGpBwsmBWk0GiQkJECj0UCv1SAsSAcAOM9+TH5RNm/yP+YtFvMWi3mLpYa8OUrOC1HPkgOApNd/wbGCq/hifE/0aBXp130RERERR8nVChaLBcuXL4fFUnILrrQfE68w+Uf5vMm/mLdYzFss5i2WGvJmwaQgu92OHTt2wG63A4BjpBynFvCP8nmTfzFvsZi3WMxbLDXkzYJJRUo7fl+4yr9YiIiI1IQFk4pElk5eybmYiIiIVIUFk4K0Wi2SkpKg1WoBABEh7MPkT+XzJv9i3mIxb7GYt1hqyJuj5LwQOUruv78dx7Pf7MLtHRri/Yd7+HVfRERExFFyTu6++25ERETgvvvuU7opTsxmMxYtWgSzueSKUv16JfMwXSrms4n8oXze5F/MWyzmLRbzFksNedeJgumpp57CJ598onQzXMiyjEOHDqH0Il9YUEmn76Jidvr2h/J5k38xb7GYt1jMWyw15F0nCqYBAwYgLCxM6WZ4VT+IV5iIiIjUSPUF09q1a5GSkoKYmBhIkoRly5a5rDN//ny0bt0aQUFBSExMxLp168Q31Ad4hYmIiEiddEo3wJsrV64gPj4ejzzyCO69916X15csWYLJkydj/vz56N27N9555x0kJycjJycHLVq0qPL+TCYTTCaT4+eioiKX5RqNBnq9HhaLxWkSLa1WC51OB7PZ7HTZUKfTQavVuizXaDRISUmBzWaDyWRCkKZkW5dNVthsdlitzoWTwWCALMsuM50ajUbY7Xan5ZIkwWAwwGazwWq1uiy3Wq2w2WxObfHFMen1emg0GqcMS5dLkuRy/1nkMdlsNgwePNjxeiAcUyk1nidJkjB48GDH5zsQjknN58lms+Evf/mL2/Vr6zEB6j1Ppd8nNpsNdrs9II5JzedJp9Phrrvucnyf+PKYKjsZpuoLpuTkZCQnJ3t8fc6cORg7dizGjRsHAJg3bx5Wr16NBQsWIC0trcr7S0tLw6xZs9zuJygoCACQkJCAoUOH4rvvvsOOHTsc6yQlJaF///5YunQpDh065FiekpKCbt26YeHChcjPz3csHzlyJLp164a0tDSYzWZYZQlAImQZuHD5GjLm/dupDdOnT0dhYSEWLFjgWGYwGDBjxgwcPnwYixcvdiyPjo7GxIkTsXPnTqxYscKxPDY2FqNGjcL69euRlZXlWO7LY4qLi8OcOXOc/kFNmDAB4eHhSE9PV/yYrl27FnDHpMbztHv3bnz//ff4/vvvA+aYasN5unDhQsAdk5rP0/fffx9wxwSo8zzl5uZi1apVPj+mUaNGoTJq1bQCkiThm2++wbBhwwCUXCEIDg7GF198gbvvvtux3qRJk5Cdne0U+Jo1a/DWW2/hyy+/rHAf7q4wNW/eHHl5eY7hhr6q4GVZxgcffIDRo0c7qvMuL/0Mi03G+mcGIDrYeb4J/lVSs2Mym834+OOP8eijjyI4ODggjqmUGs/TtWvX8P7772PMmDGOK061/ZjUfJ7MZjM++eQTjB07FpIkBcQxAeo9TyaTCR9//DHGjBmDkJCQgDgmNZ8nWZbx3nvv4aGHHoLBYPDpMV27dg0RERFepxVQ/RWmipw7dw42mw2NGjVyWt6oUSOcOXPG8fOgQYOwfft2XLlyBc2aNcM333yDHj3cz3NkNBphNBortVyv17vdRunJ9LbcZDIhPz8fBoPBse36QXoUXDHjUrEVzSKCXbYhSZLb9mk0GrfLtVqt24m+dDoddDrX01/TYyrlri2elos8poKCAsd7A+WYylLTMWk0GhQUFDh9voHafUxqP0/nzp0LuGMC1HmeZFl2fL41Go3HtntarsZjckctx2QymXDu3DmX75OK2l7ZYypfQHlSqwumUuX/mpJl2WnZ6tWrq7zNjIwMZGRkOFW5ItSvd71gIiIiInVQ/Si5ikRFRUGr1TpdTQKAvLw8l6tOVZWamoqcnBxs2bKlRtupqrA/pxYousaRckRERGpRqwsmg8GAxMREZGZmOi3PzMxEr169FGpV5en1eowcOdLp0mn9P6cWuGRiweRr7vIm/2HeYjFvsZi3WGrIW/W35C5fvoyDBw86fj5y5Aiys7MRGRmJFi1aYOrUqRg9ejS6d++Onj174t1338Xx48cxfvz4Gu1XxC05jUaDuLg4p2XXrzDxlpyvucub/Id5i8W8xWLeYqkhb9VfYdq6dSsSEhKQkJAAAJg6dSoSEhLwwgsvAABGjBiBefPmYfbs2bjpppuwdu1arFq1Ci1btqzRfkXckjOZTEhLS3PqcOa4wsTJK33OXd7kP8xbLOYtFvMWSw15q/4KU//+/b0+O2bixImYOHGioBb5VvmhmWF8PIpf8UGZYjFvsZi3WMxbLKXzVv0VpromtLRgMrFgIiIiUgsWTB5kZGSgY8eOHudr8pdQY0nBdJlXmIiIiFSjVs30rYSioiKEh4d7nQG0Oux2O86dO4eoqCjHxGdLthzHM1/twm0dGuKDh8UWa4HOXd7kP8xbLOYtFvMWy595V/b3PM+ygiRJQnh4uNMkm2Hs9O037vIm/2HeYjFvsZi3WGrImwWTgsxmM9LT0506spXekmOnb99zlzf5D/MWi3mLxbzFUkPeLJg8UKwP05+dvi+z0zcREZFqsGDyQLFHoxhZMBEREakNCyaVKe3DdLnY6nX+KSIiIhKDo+S88OcoOVmWYTabYTAYHB3ZLpus6PziagDAntmDUc+g9ek+6zJ3eZP/MG+xmLdYzFssf+bNUXK1gCzLKCwsdLqSFKzXovSzwAfw+pa7vMl/mLdYzFss5i2WGvJmweSBiE7fFosFCxYsgMVyvTDSaCSEGjh5pT+4y5v8h3mLxbzFYt5iqSFvFkweKNXpG+BIOSIiIrVhwaRCfAAvERGRurBgUpjBYHBZxskr/cdd3uQ/zFss5i0W8xZL6bw5Ss4Lf46S8+ShDzZj7f58/Pv+eNyX2EzIPomIiOoijpKrBex2Ow4ePAi73e603DF5JZ8n51Oe8ib/YN5iMW+xmLdYasibBZMHokbJLV682KXXP/sw+YenvMk/mLdYzFss5i2WGvJmweSBoqPk+HgUIiIiVWHBpEKl0woU8QoTERGRKrBgUpAkSYiOjnaZ5r30CtMVXmHyKU95k38wb7GYt1jMWyw15M1Rcl4oMUpu6ZYTmPbV7xjQPhofPnKzkH0SERHVRRwlVwvYbDZs374dNpvNaTln+vYPT3mTfzBvsZi3WMxbLDXkzYJJQVarFStWrIDV6lwYcZScf3jKm/yDeYvFvMVi3mKpIW8WTB6ImFbAE870TUREpC4smDxQclqBsCA9AOASJ64kIiJSBRZMCpIkCbGxsS69/sPK9GFin3zf8ZQ3+QfzFot5i8W8xVJD3hwl54USo+Sumq3o+MJqAMAfswYh5M9bdERERORbHCVXC1itVqxZs8alE1s9vRZaTUkVzZFyvuMpb/IP5i0W8xaLeYulhrxZMCnIZrMhKyvLZZikJEns+O0HnvIm/2DeYjFvsZi3WGrImwWTSl0vmNjxm4iISGksmFQqjJNXEhERqQYLJgVpNBokJCRAo3E9DZy80vcqypt8j3mLxbzFYt5iqSFvjpLzQolRcgDw6Edb8PPePLx2b1cM79Fc2H6JiIjqEo6SqwUsFguWL18Oi8W1n1JpH6Yi9mHymYryJt9j3mIxb7GYt1hqyJsFkwciHo1it9uxY8cO2O12l9fC65XM9n3hqtlv+69rKsqbfI95i8W8xWLeYqkhbxZMHij5aBQAaB5ZDwBw/Pw1RfZPRERE17FgUqmWDUIAAMcKrijcEiIiImLBpCCtVoukpCRotVqX19o2DAUA7D1zCWYrL/n6QkV5k+8xb7GYt1jMWyw15M1Rcl4oNUpOlmUkvvwjzl8x4+uJvdCtRYSwfRMREdUVHCVXC5jNZixatAhms2vHbkmSHEXStqMXRDctIFWUN/ke8xaLeYvFvMVSQ94smBQkyzIOHToETxf5urcqKZjWHzwnslkBy1ve5FvMWyzmLRbzFksNebNgUrE7OjaCJAFZ+/Mx4+vfse3YBdjs/MdJREQkmk7pBpBnsdGhSO0fh7d+OYjPNp/AZ5tPILyeHn3iopAS3wSDOjWGJElKN5OIiCjgsWBSkE6nQ0pKCnQ6z6fh6UHt0bdtFD759RjW7c9H4TULVu7KxcpduejSNBzPDO6APm2jBLa69qpM3uQ7zFss5i0W8xZLDXlzlJwXSo2Sc8dqs2PnyUJk5pzFp5uO4orZBgDo0jQcI3o0x9CbYlA/SK9oG4mIiGoTjpKrBcxmM+bPn1/pXv86rQaJLSMwPbkD1k4bgId7tYJeK2HXqUI8v2w3bn7lR0xdmo3cQs4O7k5V86aaYd5iMW+xmLdYasibBZOCZFlGfn5+tXr9Nwg1YubQTvh1xu14fsiNaNcoFMUWO77efgop/289Dpy95IcW1241yZuqjnmLxbzFYt5iqSHvOlEwffvtt2jfvj3atm2LhQsXKt0cn2oQasS4vm2wenI/fDWhFzo0DsO5y2Y89MFmnLrIK01ERES+EPAFk9VqxdSpU/Hzzz9j+/bt+Ne//oXz588r3SyfkyQJiS0j8NljtyKuYShyC4sx+v3fUHDZpHTTiIiIar2AL5g2b96MTp06oWnTpggLC8Ndd92F1atXK90sAIBer8fIkSOh1/uuo3ZEiAGfPHozYsKDcDj/Cp5ftttn267t/JE3eca8xWLeYjFvsdSQt+oLprVr1yIlJQUxMTGQJAnLli1zWWf+/Plo3bo1goKCkJiYiHXr1jleO336NJo2ber4uVmzZjh16pSIpnul0WgQFxcHjca3pyHmhnpYOKYHtBoJ3+0+g42HOFM44L+8yT3mLRbzFot5i6WGvFV/pq9cuYL4+Hi89dZbbl9fsmQJJk+ejOeeew47duxA3759kZycjOPHjwOA2w5iapns0WQyIS0tDSaT72+bdYypjwdvbgEAmL0iB1ab3ef7qG38mTe5Yt5iMW+xmLdYashb9TNuJScnIzk52ePrc+bMwdixYzFu3DgAwLx587B69WosWLAAaWlpaNq0qdMVpZMnT+KWW27xuD2TyeR0QoqKilyWazQa6PV6WCwW2O3XCxGtVgudTgez2exUqOl0Omi1WpfldrsdZrPZ5QOg1+shSZLL8EmDwQBZlmGxWJyWG41G2O12p+WSJGHKHe2wfOdp7D1zCQvXHsQjvVpCkiQYDAZYrVbYbDbH+r46Jr1eD41G47djMhgMsNlssFqtLsu9HZPJZILZbIbVaoXRaAyIYyql1vNU9vMdKMek1vNU+vku/awHwjEB6j1PpXmbTKaAOSY1nycALr8vfXVMZXOqiOoLpoqYzWZs27YN06dPd1p+5513YuPGjQCAm2++Gbt378apU6dQv359rFq1Ci+88ILHbaalpWHWrFkuy+fMmYOgoCAAQEJCAoYOHYrvvvsOO3bscKyTlJSE/v37Y+nSpTh06JBjeUpKCrp164aFCxciPz/fsXz48OEAgIyMDKcP34QJExAeHo709HSnNkyfPh2FhYVYsGCBY5nBYMCMGTNw+PBhLF682LE8OjoaEydOxIOdgrFgayH+vXovDq35EvFtW2DUqFFYv349srKyHOv76phGjhyJuLg4zJkzx2/HtHPnTqxYscKxPDY2tkrHtGnTJgwcODCgjkmN52n37pL+c3Pnzg2YY1L7eQKAgoICvP/++wFzTGo/T3Pnzg24YwLUd54GDRrkyNvXxzRq1ChURq2a6VuSJHzzzTcYNmwYgOv9kzZs2IBevXo51nv11Vfx8ccfY9++fQCA5cuX4+mnn4bdbse0adPw+OOPe9yHuytMzZs3R15enmMGUF9eYXrttdcwZcoUGI1Gx3JfVvAWixUj3vsV248X4s4bo/HW326qU3+VlL/CNHfuXDz99NMICQkJiGMqpcbzdPXqVbz++uuOz3cgHJOaz1Pp53vatGku/Txq6zEB6j1PxcXFmDt3LqZMmYLQ0NCAOCY1nye73Y709HSn35e+OqZr164hIiLC60zfAVEwbdy4ET179nSs98orr+DTTz/F3r17q72vjIwMZGRkwGazYf/+/X55NIrdbse5c+cQFRXl145s+85cQvJ/1sIuA6ue6ouOMco+4kUpovKmEsxbLOYtFvMWy59514lHo0RFRUGr1eLMmTNOy/Py8tCoUaMabTs1NRU5OTnYsmVLjbZTEUmSEB4e7vdO6O0bh2FI1xgAwIKsQ17WDlyi8qYSzFss5i0W8xZLDXnX6oLJYDAgMTERmZmZTsszMzOdbtGpldlsRnp6upBn40xIigUArPz9NI6eu+L3/amRyLyJeYvGvMVi3mKpIW/VF0yXL19GdnY2srOzAQBHjhxBdna2Y9qAqVOnYuHChfjggw+wZ88eTJkyBcePH8f48eMVbLX6dIypj9s6NIRdBt5ZW3evMhEREVWH6kfJbd26FQMGDHD8PHXqVADAmDFj8NFHH2HEiBEoKCjA7NmzkZubi86dO2PVqlVo2bJljfZbtg9ToJjYPxY/783DV9tOYdLt7dA4PEjpJhEREdUKqr/C1L9/f8iy7PLfRx995Fhn4sSJOHr0KEwmE7Zt24Z+/frVeL8i+jCJ1r1VJG5uFQmzzY5Pfz2qdHOIiIhqjVo1Sk4Jle09Xx2yLMNsNsNgMAjryLZqVy4mLt6ORvWN2PDMbdBpVV8z+4wSeddlzFss5i0W8xbLn3nXiVFy/pSRkYGOHTuiR48eftuHLMsoLCx0+/gWfxl4YyNEhhhwtsiENfvyvb8hgCiRd13GvMVi3mIxb7HUkDcLJg9E3JKzWCxYsGCBy0Rf/mTQaXBPQsnDiJduPSFsv2qgRN51GfMWi3mLxbzFUkPeLJjqoPu7NwcA/Lw3D+cu88GRRERE3rBgqoPaNw5D12bhsNpl/C/7tNLNISIiUj0WTB6I6MMElEy+qYT7E5sBAD7ffLxO3YNXKu+6inmLxbzFYt5iKZ03R8l54c9RckoqKragV9rPuGyy4sNHemBA+4ZKN4mIiEg4oaPkbDYbsrOzceHCBV9srs6w2+04ePCg0xOlRakfpMcDPUr6Mi1cd1j4/pWgZN51EfMWi3mLxbzFUkPe1SqYJk+ejPfffx9ASbGUlJSEbt26oXnz5lizZo0v2xfQLBYLFi9erFiv/zG9WkEjARsOFuDA2UuKtEEkpfOua5i3WMxbLOYtlhryrlbB9OWXXyI+Ph4AsGLFChw5cgR79+7F5MmT8dxzz/m0geQ/zSODcUfHRgCADzYcVbYxREREKlatguncuXNo3LgxAGDVqlW4//770a5dO4wdOxa7du3yaQOVIqrTt9Ie7d0aAPDlthM4eeGqwq0hIiJSp2oVTI0aNUJOTg5sNhu+//57DBw4EABw9epVaLVanzZQKSImrpQkCdHR0YpOq39LmwboHdcAFpuM//x4QLF2iKCGvOsS5i0W8xaLeYulhryrNUpu5syZmDdvHpo0aYKrV69i//79MBqN+OCDD/Dee+9h06ZN/mirIgJ1lFxZO45fwN3zN0IjAZlTkxAbHap0k4iIiITw6yi5mTNnYuHChXj88cexYcMGGI1GAIBWq8X06dOr1+I6yGazYfv27bDZbIq2I6FFBAbe2Ah2GZibuV/RtviTWvKuK5i3WMxbLOYtlhryrva0Avfddx+mTJmCZs1KJkC8ePEixowZg7/+9a8+a1ygs1qtWLFiBaxWq9JNwf/d2Q6SBHz7ey725BYp3Ry/UFPedQHzFot5i8W8xVJD3tUqmP71r39hyZIljp+HDx+OBg0aoFmzZvj999991jgS58Ym9TGkSxMAwFs/H1S4NUREROpSrYLpnXfeQfPmJZMeZmZmIjMzE9999x0GDx6Mp59+2qcNVEpdGSVX1pO3tQUArNqdi/11YF4mIiKiyqpWwZSbm+somL799lsMHz4cd955J6ZNm+bXUWUiiRolFxsbq5pRFu0bhyG5c2PIcmBeZVJb3oGOeYvFvMVi3mKpIe9qjZKLiYnBl19+iV69eqF9+/Z4+eWXcf/992Pfvn3o0aMHiooCpw9MXRglV9Yfpwsx5M31HDFHRER1gl9Hyd1zzz148MEHcccdd6CgoADJyckAgOzsbMTFxVWvxXWQ1WrFmjVrVNVpsFNMuGPEXEaAXWVSY96BjHmLxbzFYt5iqSHvahVMc+fOxRNPPIGOHTsiMzMToaElVyFyc3MxceJEnzYwkNlsNmRlZaluWOpTt5cUvf/beRonzgfO7N9qzTtQMW+xmLdYzFssNeStq86b9Hq9287dkydPrml7SAW6NrsBfdtGYd2Bc3h37WG8NKyz0k0iIiJSVLXnYTp06BCefPJJDBw4EHfccQeeeuopHD582JdtIwVN7F9ylWnp1hPIv2RSuDVERETKqlbBtHr1anTs2BGbN29G165d0blzZ/z222+OW3RUORqNBgkJCdBoql23+s2tbSKR0OIGmKx2fLDhiNLN8Qk15x2ImLdYzFss5i2WGvKu1ii5hIQEDBo0COnp6U7Lp0+fjh9++AHbt2/3WQOVkpGRgYyMDNhsNuzfv7/OjJIrKzPnLB77ZCvCjDpsmHEb6gfplW4SERGRT/l1lNyePXswduxYl+WPPvoocnJyqrNJ1RExD5PFYsHy5cthsVj8to+auL1DQ7RrFIpLJis+3XRM6ebUmNrzDjTMWyzmLRbzFksNeVerYIqOjkZ2drbL8uzsbDRs2LCmbaoz7HY7duzYAbvdrnRT3NJoJEzoHwsA+GD9ERRbavdoELXnHWiYt1jMWyzmLZYa8q7WKLnHHnsMjz/+OA4fPoxevXpBkiSsX78e//rXv/B///d/vm4jKSilawz+vXo/Tl28hm92nMLfbm6hdJOIiIiEq1bB9M9//hNhYWF44403MGPGDAAls3/PnDkTkyZN8mkDSVk6rQaP9G6Fl1fuwfvrj2BE9+bQaPgoACIiqluqdUtOkiRMmTIFJ0+eRGFhIQoLC3Hy5EmMGzcOa9eu9XUbA5ZWq0VSUhK0Wq3STanQiB7NEWrU4WDeZWQdyFe6OdVWW/IOFMxbLOYtFvMWSw15V2uUnCc7d+5Et27dAmrm07r2LDlPXv42BwvXH0GfuCgsGneL0s0hIiLyCb+OkiPfMJvNWLRoEcxms9JN8erh3q2g1UhYf/Ac9uTWzocr16a8AwHzFot5i8W8xVJD3iyYFCTLMg4dOgQfXuTzm2YRwUju3BgA8P762jmRZW3KOxAwb7GYt1jMWyw15M2CiSptXN82AID/ZZ9CXlGxwq0hIiISp0qj5JYvX17h60eO1M4rD1Q5NzW/Ad1bRmDrsQv4ZNMxPD2ovdJNIiIiEqJKBdOwYcO8riNJgTHkvOyjUfxFp9MhJSUFOl21ZndQxLi+rbH12AUs+u0YUgfEoZ6h9owQqY1512bMWyzmLRbzFksNeft0lFwg4ig5Zza7jP7//gUnzl/Dy8M6Y9StLZVuEhERUbVxlFwtYDabMX/+/Fo1ykKrkfBo79YASh6XYrfXnnq7NuZdmzFvsZi3WMxbLDXk7dOC6cKFC/jkk098ucmAJssy8vPza90oi/u7N0dYkA6Hz13BL/vylG5OpdXWvGsr5i0W8xaLeYulhrx9WjAdP34cjzzyiC83SSoUatThwT+fKfd2FofVEhFR4KtS76miooonLLx06VKNGkO1x8O9W+HDjUex5egFbDxUgN5xUUo3iYiIyG+q1Olbo9FUOApOlmVIksRHo1SS3W7H4cOH0aZNG2g0ta872czlf+CjjUfRo1UElv69p+pHSNb2vGsb5i0W8xaLeYvlz7wr+3u+SgVTeHg4nnvuOdxyi/tniR04cAB///vfWTDVEWeLitH3tV9gttrx6dib0bdttNJNIiIiqhK/jJLr1q0bACApKcntfz169GB/liowmUxIS0uDyWRSuinV0qh+EEbdUjKtwOur96n+3Nf2vGsb5i0W8xaLeYulhryrVDA9+OCDCAoK8vh648aN8eKLL9a4UXVJbR+SOnFALEIMWvx+shCrdp1Rujle1fa8axvmLRbzFot5i6V03lUqmB577DE89dRTHl83m804duxYjRtFtUdUqBGP9St5xtzrq/fCYrMr3CIiIiLf82nPqfPnz+Pjjz/25SapFhjXtw2iQg04WnAVn20+rnRziIiIfM6nj0bZuXMnunXrxk7flWS323Hu3DlERUXV+lEWn246in/+7w+EGnX4fnJfNIsIVrpJLgIp79qAeYvFvMVi3mL5M28+GqWMu+++GxEREbjvvvuUbooTSZIQHh6u+uH4lfHgLS3RrcUNuGyyYtqXv6vykSmBlHdtwLzFYt5iMW+x1JB3nSiYnnrqKVU+ssVsNiM9PV3xjmy+oNVIeGP4TQjSa7DxUAEW/aa+vmyBlHdtwLzFYt5iMW+x1JB3lWb6vueeeyp8/eLFizVpi98MGDAAa9asUboZAa91VAhmJN+IF5f/gbRVe9G3bTRaR4Uo3SwiIqIaq9IVpvDw8Ar/a9myJR566KEqNWDt2rVISUlBTEwMJEnCsmXLXNaZP38+WrdujaCgICQmJmLdunVV2geJM/rWlujZpgGuWWx4+oudsKnw1hwREVFVVekK04cffujzBly5cgXx8fF45JFHcO+997q8vmTJEkyePBnz589H79698c477yA5ORk5OTlo0aLkAbCJiYluJ7P64YcfEBMTU6X2mEwmp22VPj+v7HKNRgO9Xg+LxQK7/foweq1WC51OB7PZ7DSJo06ng1ardVle+t7ybdfr9ZAkyeXSo8FggCzLsFgsTsuNRiPsdrvTckmSYDAYYLPZYLVaXZZbrVanzvm+Oia9Xo/X7uuKwf9Zi23HLuDtX/ZjXJ9Wqjim0pytViuMRmOVjkmj0QTceRJxTMD1z3egHJNaz1PpOmU/67X9mAD1nqfS9ptMpoA5JjWfp1Jl2+OrYyqbU0WqVDD5Q3JyMpKTkz2+PmfOHIwdOxbjxo0DAMybNw+rV6/GggULkJaWBgDYtm2bz9qTlpaGWbNmuW1H6aSdCQkJGDp0KL777jvs2LHDsU5SUhL69++PpUuX4tChQ47lKSkp6NatGxYuXIj8/HzH8gcffBDTp0/HnDlznD58EyZMQHh4ONLT053aMH36dBQWFmLBggWOZQaDATNmzMDhw4exePFix/Lo6GhMnDgRO3fuxIoVKxzLY2NjMWrUKKxfvx5ZWVmO5b46ppEjRyIuLg7dNUeRheZ4I3M/DqxdhmdTH1HNMW3evBkDBgyo8jEF4nny5zHt2bMHADB37tyAOSa1n6cpU6agqKgIb7/9dsAck9rP09y5cwPumAD1naeUlBR07drV8X3iy2MaNWoUKsOn0wrUlCRJ+OabbzBs2DAAJZ28goOD8cUXX+Duu+92rDdp0iRkZ2c7BerNmjVr8NZbb+HLL7+scD13V5iaN2+OvLw8x3BDX1XwWq0W58+fR1hYmFMFHQh/lRQXF+Pvi7ORdaAAnWLC8PWEXjDotIoek91uR0FBARo2bAiDwVBr/9KqLX89WiwWnD17Fg0aNHA8uLu2H5Oaz5PdbkdRUREaNGjgMrVLbT0mQL3nyWazoaCgAA0aNIDRaAyIY1LzedJqtThz5gwiIiIcvy99dUzXrl1DRESE9+mDZBUBIH/zzTeOn0+dOiUDkDds2OC03iuvvCK3a9eu0tu988475aioKLlevXpy06ZN5c2bN1f6vYWFhTIAubCwsNLvqazi4mJ55syZcnFxsc+3rQZnCq/JXWeulls+8608L3O/0s0J+LzVhnmLxbzFYt5i+TPvyv6erxXTCpSfd0GW5SrNxbB69Wrk5+fj6tWrOHnyJHr06OH1PRkZGejYsWOl1iX3GtUPwuy/dgIA/L+fD2DzkfMKt4iIiKh6VF0wRUVFOS7DlZWXl4dGjRr5dd+pqanIycnBli1b/LqfQDc0PgZDujSB1S5j+Dub0Gr6ShQVW7y/kYiISEVUXTAZDAYkJiYiMzPTaXlmZiZ69eqlUKt8y2AwKN0Ev5IkCf++Px63tI50LOs68wf8e/U+Ra44BXreasO8xWLeYjFvsZTOW/FO35cvX8bBgwcBlPSEnzNnDgYMGIDIyEi0aNECS5YswejRo/H222+jZ8+eePfdd/Hee+/hjz/+QMuWLf3WroyMDGRkZMBms2H//v1+eZZcXWKx2dH2ue/cvjZlYDv0bx+NLk3DodHwMQNERCROZZ8lp3jBtGbNGgwYMMBl+ZgxY/DRRx8BKJm48rXXXkNubi46d+6MuXPnol+/fkLa5++H7x4+fBht2rSpMw9vPFNYjE82HcX8NYdcXosI1qNR/SA0vaEeFoxKhEHn20zqYt5KYt5iMW+xmLdY/sy71jx8t3///pBl2eW/0mIJACZOnIijR4/CZDJh27Ztwoolf7NYLFi8eLHLMMxA1jg8CNMGd8DR9CFY8vitGNK1CQZ1aoRQow4Xrlqw98wl/LQ3D+2e/w6tpq9Eq+kr8eGGIz7Zd13MW0nMWyzmLRbzFksNeSs+cSXVXbe0aYBb2jQAUHLLbsfxi3jog99QbHGedXXWihzMWpEDANj/crLPrzwRERF5w4LJg7J9mMj/9FoNbm4dib0vJcNktSF53jocPnfFZb12z1/vB/X6fV3RJjoUiS0jRDaViIjqIBZMHqSmpiI1NdVxb9MfJElCdHR0leaUqguMOi1+fro/AMBqsyPOQ2fxf3z5u8uyIL0GO1+8E1pJgk7rfCWKeYvFvMVi3mIxb7HUkLfinb7Vzp+dvqlqrDY7ftmXj8c+2Vrp90SHGTGgfTRS4mPQIjIYwQYdGoQYOBqPiIgA1KJRcmrnz4LJZrNh586diI+Ph1ar9em264LCaxb839Kd+HHP2Wpv4//9LQF94qIQEcL5VHyNn2+xmLdYzFssf+Zd2d/zvCXngYg+TFarFStWrECnTp34D64awuvpsXBMd6dlF66YMer935B/yYS8SyYP77zuyc92OP2884U7AQmADIQH633Z3DqHn2+xmLdYzFssNeTNgskDEX2YyPciQgxY+VRfp2WyLCNrfz4e/tD7Y27iZ//gsix1QCxaRoZgeI/mVX6OIRERBQYWTBTwJElC//YNsW/WQKSnp2P69OnQ6w1465eDmJO53+v7M34pmWRz2lfOncx/e/Z2NKof5Jc2ExGRurBgUpAkSYiNjeUVC0HK5q3RSHjq9rZ46va2jtcvm6x4ZeUefLb5eKW2d8urPzn9nPFgNwzp2sSnba7N+PkWi3mLxbzFUkPe7PTtBUfJ1W2FVy1ub9NV5OZWkZg0sC1GLvwNY3q2xKy/dvZT64iIqKY4Sq6GRDx812q1Yv369ejTpw90Ol7s8zdf5b3t2Hncu2BTld/315tiMDOlU50ZkcfPt1jMWyzmLZY/8641z5JTq9TUVOTk5GDLFu8dhavLZrMhKyuLs4kL4qu8E1tG4mj6EMd/2S/cUan3/S/7NBJeynQ8I6/V9JXYcPBcjdqiZvx8i8W8xWLeYqkhb5bFRDV0Q7ABR9OHOH5euz8fD32wuVLvHbnwNwBwej8REakPCyYiH+vXLtpRAMmyjF8Pn8ff3vu1wve0mr7S8f9bnhuIqFADO5MSEakICyYFaTQaJCQkQKPhnVERlMhbkiT0jG3gKKAsNjvaeng2Xqker/zo+P8pA9vhidviUHjNAqNOgxBj7fkny8+3WMxbLOYtlhryZqdvD0R0+ibaf/YS7py7ttLrv/VgAjo0ro+WDYKh1/KLmoioptjpu4ZEdPq2WCxYvnw5LBaL3/ZB16kx73aNwhydx78c39Pr+k/8dwcGzslC2+e+w0aVdxhXY96BjHmLxbzFUkPeLJgUZLfbsWPHDtjtdqWbUieoPe/urUpG3x1Juwv/S+3tdf0HF/6GVtNXYvjbm3C2qNgx8m7bsfMCWuud2vMONMxbLOYtlhryZsFEpDKSJCG++Q04mj4EO1+8E1n/6F/h+puPnneadfzeBZuQfeKifxtJRFTH1J4epER1UHg9PcLr6R2dxid9vgP/yz7t9X3DMjYAAEIMWvw+cxC0Go64IyKqCV5hUpBWq0VSUhK0Wq3STakTAiHv/zyQ4OjzVBlXzDbEPrsKL/5vt59b5ioQ8q5NmLdYzFssNeTNUXJe8FlypHaf/noM/1zmvSBKaheNd0YnIkjPL3giolIcJVcLmM1mLFq0CGazWemm1AmBmvfoW1s6rjo9P+RGj+tl7c9Hh39+j7+9W/Ekmr4SqHmrFfMWi3mLpYa8WTB5kJGRgY4dO6JHjx5+24csyzh06BB4kU+MupD3uL5tcDR9CFY+1cfjOpsOF6DV9JVYuz8fe88U+S2PupC3mjBvsZi3WGrIm52+PUhNTUVqaqrjUh1RbdIpJhxH04fAbpfR5tlVbtcp+7y7ddMGoHlksKjmERHVOrzCRBTANBoJR9OHYOvzA/HsXR08rtf3tV+w+1ShwJYREdUu7PTthT87fdtsNuzcuRPx8fEcaSEA8wasNjvivDzLDgCOpN1V44f/Mm+xmLdYzFssf+Zd2d/zLJi84Cg5CkQXrpiR8FKm1/U2Tr8NMTfUE9AiIiJlcJRcLWA2mzF//nyOshCEeV8XEWLA0fQhWP/MgArX65X+M1pNX4knP9uBhz/cDFmW8Zf/t87xGJaDeZc9vpd5i8W8xWLeYqkhbxZMCpJlGfn5+RxlIQjzdtUsIhhH0u5Cj1YRFa63YudprNmXj5S31mP3qSLH8oFzstD/9V/cvod5i8W8xWLeYqkhb46SI6rjJEnCF+N74fwVM95ZewjvZB32uG7ZYqnU0YKr/mweEZEq8AoTEQEAIkMMmJF8Iw68kqx0U4iIVIcFk4L0ej1GjhwJvV6vdFPqBOZdOXqtBkfThyA2OqTS7zlTWAwAsNjsmLokG0u3noBer8egYcPx2dbTuGq2+qu59Cd+vsVi3mKpIW+OkvOCo+Sorhv+9iZsPnre63otIoMxoX8sZny9CwBwNH0I/vrWeuw8WYh7ujXFnOE3+bmlRERVx1FyNSTi0SgmkwlpaWkwmUx+2wddx7yrZ+n4ntj2/ECv6x0/f9VRLAElee88WTIZ5tfbT3l8nyzLGPfxFqT+d3vNG1uH8fMtFvMWSw15s2DyIDU1FTk5OdiyZYtf98MhqWIx7+ppEGrE7lmDqvSec5edv9jinl2F9QfOuayXW1iMH/fkYeXvubhi4q27muDnWyzmLZbSebNgIqJKCTXqcDR9CPa+NBgZD3bzun7v19c5/Wy1yxj1/m8VvufEhZIRd1dMVtjs7C1AVNvsOH4Bt776E1bsPK10U3yOBRMRVUmQXoshXZtgz+zB6NcuusbbK/sElsHz1uHcZRM6vbgad8/f4LTexav8a55I7R7/dBvOFBXjyc92KN0Un2PBpCC9Xo8JEyZwlIUgzNu36hm0+OTRmzFneHyNtqMp98y6n/fmAQB+/7P/k8VmR6vpK3HT7Ex8sfVEjfYVyPj5Fot5u2ey2PyyXTXkzYJJQZIkITw8vMYPOaXKYd7+cU+3Zj7dnl7rfH5W/3HG8f/PLdvt030FEn6+xWLermx2Gf64kb7pUAEG/DsLudc0iubNgklBZrMZ6enpindkqyuYt/8cTR9S7ffay81sotVc/1paf+Acnvjv9Uv7nAXFM36+xWLezkxWG/q99gsuFft24EZRsQV/e+9XHDt/FX9d8BufJUdEtd/R9CH47dnbva73f0t3OnXoLt+3O+f09cevlO8kbrHJKLbYkPbdHmytYG6ow/mXYbbaK9nyuiG38Br+/ulWZJ+4qHRTKADtPFGIUxev+Xy7Uz7P9vk2q4sFExH5TKP6QVg3bUCF63y1/SRGLfwNv+zNQ6vpK7Fsh/McTW9nHarw/c989TveyTqM+97eBAD4fvcZp218v/sMbnsjCw99UPGIvLqmZ9rPWP3HWQzL2OB9ZSKV+OnPPo1qwIKJiHyqeWQwfvq/pArX2XS4AI98VDLH2eur91Vp+//Lvj5c2WaXMX7RNkxeko28S8Ww2uwYv2gbAODXw+fx4YYjbjuKXyq2YOOhc3XmFt/a/flKN4Go1mPBpCCDwYDp06fDYDAo3ZQ6gXmLExsdik/H3uz3/ZTt/1R0zYoNhwqcXp+1Igf/+PJ33PbGGiz+7Zhj+T+++B0PvvcbPtl0DIGios/3q6v2KNCiwOaL75Mfc87iUP5lH7Yq8Cn5/c2CSUGyLKOwsLDO/JWrNOYtVu/YBlj3VCL2vTQIf09q45d9tH3uO8f/Hz9/xWO/pcP5V/DcN9dH2H3/58i7L7adQP4lE9bsy1P8c3Hhihmf/noMhVct1Xp/RZ/vvWcu1bR5VE5Nv082HSrAuE+24vY3snzcssCm5L9TFkwKslgsWLBgASyW6n1BUtUwb7EsFgs+eO8dwG7D9MEd/L6/Rz/aiqPnrnhdb+Mh58ezDJyThYc/3OJ0q08J4z7Zin8u242nv9xZrfdX5fNdcJnPP6upmn6f7Dx50bcNUpjVLmaQhZLf3wFfMJ04cQL9+/dHx44d0bVrV3zxxRdKN4mozpEkCT9O7ef3/bxSiVtPn5a5Dbf7VBEKr5V8Ab+//oiif71uO3YBAJCZc9bv+7rmp8kFqe5asiXwJ5UN+IJJp9Nh3rx5yMnJwY8//ogpU6bgyhXvf4USkW/FNQzDx4/6v1+TNxqN+4nvdp0qRMJLmRjzwWa0mr4SH6w/UqP9XLxqxjWzOguTo+eu4o/ThXxeH/nMsYKrSjfB7wK+YGrSpAluuukmAEDDhg0RGRmJ8+c9z98iGjsgi8W8xSqfd5IPnj1XE4VXLVj5e67H1y9etSDrzxFls7/NwYGznvv+FFtsWLrlBM65ub1VeM2Cm2ZnIn7WDzVvdBVU9vM96v3fMOTN9XhlJTuD10RNvk8CrStl+QloA5HiBdPatWuRkpKCmJgYSJKEZcuWuawzf/58tG7dGkFBQUhMTMS6detcN1QJW7duhd1uR/PmzWvYat8wGo2YMWMGjEaj0k2pE5i3WJ7y3vfyYDzcq5UibYqfXbUC5o65azHty53oMnO1y6R8L6/MwbSvfkf3l390Wv7B+iOOQslsEzd5ZnU+3x9sqNlVtLqM3yfORNVLSuatU2zPf7py5Qri4+PxyCOP4N5773V5fcmSJZg8eTLmz5+P3r1745133kFycjJycnLQokULAEBiYiJMJte/8n744QfExMQAAAoKCvDQQw9h4cKFFbbHZDI5bauoqMhluUajgV6vh8Vigb1MRzetVgudTgez2ezUF0Kn00Gr1bos12q1OHr0KJo2bQpNmcdB6PV6SJLkMgW8wWCALMsund6MRiPsdrvTckmSYDAYYLPZYLVaXZZbrVbYbNdvF/jqmPR6PTQajcv5UMMx2e12HD16FLGxsTAYDAFxTKXUeJ4sFgsOHjyIVq1aQaPROJZrIWPGoDjkXryK1TnqmZTOk6VbTwIAeqf/jGE3xSB92I349cgFLPr1uGOdsudp9rc5Tu/fejgfXZrWB1DxeSqr9LxU5TzZ7XacPHkSrVu3dvrMeBOInz0Rx2Sz2XD06FG0atUKRqOxysd08sL1W1il71P6mGpyntzd6DaZTD45prKuXbvm+H3pq2OyV7LDuiQrPZa2DEmS8M0332DYsGGOZbfccgu6deuGBQsWOJbdeOONGDZsGNLS0iq1XZPJhDvuuAOPPfYYRo8eXeG6M2fOxKxZs1yWT58+HUFBQQCAhIQEDB06FMuXL8eOHdefc5WUlIT+/ftj0aJFOHTo+mzFKSkp6NatG+bPn4/8/OsTyA0fPhxLly51/PIuNWHCBISHhyM9Pd2lDYWFhU5ZGAwGzJgxAwcPHsTixYsdy6OjozFx4kRs374dK1ascCyPjY3FqFGjsGbNGmRlXR/O6qtjGjlyJOLi4pCWlqbaY+rduzcGDhwYUMekxvO0efNmfPfd9WH/5Y/JLgOrTB2QL4eiNrnLsBerzM6j/v4zIBjZv67FGVsovjO7jghspT2PIFgx/Y7Wbs9T74F3YdyK68XjI/W2Aqj6eQKAsWPH4v3333f8bDAY8E5hV4/H8/XwJtX67FlkDfZYG+L+nm3xwJDbVPXZqw3/ntq/eP3K5CP1ttb6Y9oScRt2l3msEQD8Pfz3Gh/Th9e6O22z9N+GL49p1KhRiIuLQ2FhIerXrw9PVF0wmc1mBAcH44svvsDdd9/tWG/SpEnIzs52+pB4IssyHnzwQbRv3x4zZ870ur67K0zNmzdHXl6eI0hfVfB2ux2vvfYapkyZ4nSZsbb9pVVb/no0mUyYO3cunn76aYSEhATEMZVS43m6evUqXn/9dcfn29Mx3fvOZpcvWjW7udUN2Hz0otOyIV0aY859nTHu0x1Yd7DA/RsBHHjpTuj1ephMJuw+XYR2DUNh0GnwR+5l3PP2r4719s0aiItXLdhyvBDxzSMQVU/j1Fn9g00nsPfMJaT99UZo/1x++eo1vPXmfzBt2jSnK9YAnH45l3folcHV+uw98/UfWLYzF7HRIfhuUj/844ts9GoTgWE3lVzVD/R/T8XFxZg7dy6mTJmC0NDQKh9T6xmrHD/vmzVQFcdUk/N0/7tb8PupQqdl+2YNrPExlf/s/v5sX8fvS18d07Vr1xAREeG1YFL8llxFzp07B5vNhkaNGjktb9SoEc6cOVOpbWzYsAFLlixB165dHf2jPv30U3Tp0sXt+kaj0e09UnfL9Xq922146ghYfnnZy7Ce9lmeJElul2s0GrfLtVottFqty3KdTudyGwCo+TGV8nSfWQ3HVLpOIB1TKbUdU+m2yr5e/piWpfbGZZMV3V7KdHkQrxqVL5YAYOWuM1i5y/t30jfZZxAZYsC4T0r+Sh7QPhofPnIzDPpip/WuWiX0e2MdTGUm4lzy+K24pU0DAMC/vi95nMxfusbgjo6N8ML/dmPRr8dwt8Ho8Xx4Uv6zdzDvMlbtOoZH+7RGqJvtlH72lu0s6Tx/KP8KPtt8HP/bmYv/7czFxWI7Hu/XBpJUUsiJ+Oz9v58OIP+yCbP/2tntMZXy5b+n0l/EpbfjqnpMnl6vynfE+StmvPnTAdzfvRk6xYQ7vebtmExWG9o//z0A4EjaXdDr9VizPx+xUaFo0SDYa9vLL8+75NotpnQdX33vlW6z/LZq+r3nrkuPO6oumEqV/sMrJcuyyzJP+vTpU+n7k2VlZGQgIyOjSn0BqkqSJERHR1f6WKhmmLdYlc1bp9XghmADxvZpjffWBXYn5Glf/e708y/78rHj+AUcznee6iThpUyX945491dk/aM/Ji7e7lh2qbjkr/bSR7zs17V2+31ZEbtdxnPLdqNjTH0ktojAXW+WDKrJLSzGhKRYfLDhCMb2aY3mkcEet/Hi8j8c/5/23V60bBCCwZ0bV7hfX7HbZbyRuR8A8HCvVmgTXbNbvH+cLsSKnblIHRCLsCD3RQegju+TJ/67HRsPFeCjjUdxNH1Ihesezr+M5pHB0GtLiruNZa6EbjhYAL1WwiMfbkFUqBFbnx9Y5bacKSp2Wfa3d3/FM8kdcFPzG6q8PU+UzFvVBVNUVBS0Wq3L1aS8vDyXq06+lpqaitTUVBQVFSE8PNz7G6rBYDBg4sSJftk2uWLeYlU170d6B37B5M7d8zdWet2k19dU+PquK6H47VghWkeFoFlESYHzn58OVPieoRnrsfuU6y3RzzYfx2ebSzq2r92fj5+f7l/pdo5ftA3xzcLxxfheMOh8Nxh7yZbjOFtkwlO3t3UsKzsSsTJXKK+YrPjjdBFuCNbjcP5lDO7cxOn1IW+uB1AyNUTaPe7vRADXP9+XTVbsPn4BCc1vqPYv8zOFxWgcHuS0bMfxC2hYPwhNb6jnWCbLMg6fu4LWDUJw/qoZG8s8O7F04tVxfV0fQ/S/7FOY9Hk2ktpFO+ZCu2K+fivswlWzYwoNd9NkVNemwwUYlrHBazFXFXyWnAcGgwGJiYnIzHT+ayszMxO9evVSqFW+Y7PZsH37dr9exaLrmLdYVc07pswvBqqcqUt34sdyM4OPfn8z+vzrFwDAifNXMe/Higsmd8VSeYcr8ciZ8naeLMTPe53bZnUzzcKczP0Y9/GWSk2i+cxXuzAncz/WHziH439OlFj2AtqZwutXOfafvYStR13n3Ov04moMf2cT7py7FuMXbXd5VI6j/ScuVtiWc5euIWP5BvzlzXW4Z/5GLMs+5bX9njzw7iannw+cvYS7529E7/SfnZb/56cDuP2NLIxftA1f/Dl6s9RL3+bg5ZV7cP7K9b5FhVct+GD9EUz6PBsAHHOMAc65la/z8txcLfKlvKJiXDZZva/ohpLf34oXTJcvX0Z2djays7MBAEeOHEF2djaOHy/5y2bq1KlYuHAhPvjgA+zZswdTpkzB8ePHMX78eL+2KyMjAx07dkSPHj38tg+r1YoVK1Y4dXoj/2HeYlUn7yNpd2HTjNt8+hdpoCvtD1WeLMvo+9ovPt2X1WZ33AasjPlrro9ceuqzHeg66wf8ergA76495JgF/c2fDuDHPXn4Za/rA5D/l30KM5f/AbtdhqVMsTXq/d/Q7/VfcLaoGEcLrjgtL3Xn3LW47+1NyC10nj+rvNL+YIDz7UtvEzE++tFWvL7xIo7+Wbgt21HyLEK7XcZ9CzZi7EdbKv2onaMFV9Fq+kpk/HIQS7eewPqDzkVc4TULlm494Sh+f8g5i399v9ftti4XX//3Nn7RNpdpLjq98D1W/3EGG8rsQ4KES2UKmJtf/Qm3v7EG837cD/ufhezJC1cxYdE2bDtWs4mfL1wxo+9rv2DQ3LU4mHcZU5dm48i5Kzh32eR0jj1R8vtb8VtyW7duxYABAxw/T506FQAwZswYfPTRRxgxYgQKCgowe/Zs5ObmonPnzli1ahVatmzp13aJuCVHRM4kSUKT8JIrTR2b1EdOrvPVj50v3il89uza6pZXf/Lp9ootNnT4Z0kn4fXPDPCydonfTxZi46FzOH2xGMt3lhQUD7xbMhrw3GUznr3rRse6i347hilLs/HeQ91x65+d20uvjFy8asYyNw9H/uN0Id74Yb/L8rKFSs+0n3HwlWTotO6vD5S9kvTbkevFwN4zl1Bw2QSzzY7wenoYtBqkf7cXveIaYED7hvjdw5W504XXsPXP5wJeNduw8+RF1NNrcVPzG3DNYkOwQecyCWqp11fvc1l27rLJZXLUiuw+XYgWDYLxnx8PYNNh1xGbV8w2/P3TbU7Llmw9gbVlrj4BJZ355/14AFGhRgzp0sRx1fK73Wdq9AfN9uMXYLLaceriNQycUzLS/evtJVfnbmxSH99N6lvtbfub4gVT//79vVbhEydOZN8Tojrmi/E90enF1Y6fF4+7BeH1PHfCJWfuRi3VRNlbe1W5cvXge7+5Xf7u2sM4cf765I1r9pX8wn7g3V/RPLIe1k27zfGau2IJAF5dtRcH8y67LM/45aDTz31f+wXrn7nNMQWDJ6t2OT82Z+rSncjan4/wenqMvrUlFq4/goXrj+DtUYku783an49rZpvTw513nSp0Of53Ric69UvypirFEgBMXLwdO/55B+b+6FpIelK+WCpr2Y5TeH7Zbqdl9y3YiIEdG2F8Uiwum6zoXObfqTt7zxShXcMwdJ65GlcreL7intwiWGx2/LTnLJpHBkNyOx2mchQvmOoySZIQGxvLUVuCMG+xapp3iFGHJwbE4a0/f/n1jovyZfOoit7Oun57zVez93232/1UDCfOX0NBJTofuyuWWk1f6bIst7AYsc+uws2tIt1uZ/T7v6F+Pb3LcwZL+/wUXrM4PodAya0ud15ZleM0A3zp1bSyyl/d8YeXffiMwNKrZeWXbT12AVfNNrzpZVABUDKKc0iXJhUWS6UWrjvi8XYjoOwoOVVNXKkmZacV2L9/v9cJrYjI98xWO5bvPI3ecQ0ct+pKfyHe062p41I+BZ4OjcOw94znhx9TYGrZIBjHCq56fN0f/RtLu954+z2veKdvtUpNTUVOTg62bNnit31YrVasWbOGnZAFYd5i+SJvg06D+xKbOYqlsjS8UhjQWCzVTRUVS4Cynb5ZMCnIZrMhKyuLw9wFYd5i+Ttvb6OYiCjw1OlpBYiIqsOXswcTEXnDgskDEfMwEVHVfftkH8xI7oAHb26hdFOIqA7hKDkPRMzDpNFokJCQ4PJkcfIP5i2Wv/Lu3DQcnZtybjSiukjJ728WTArS6/UYOnSo0s2oM5i3WMybiHxNr1duLjb+qa0gi8WC5cuXw2Kp/KMGqPqYt1jMm4h8TcnvExZMCrLb7dixYwfsdu/Pz6GaY95iqSXvT/58OrsnPVpFVHpb2/95Bz58hP0aiZSi5PcJCyYP2OmbqPb6cWqS4/91Xh6HMXNop0pvNzLEUK32DLspplrvIyL1YMHkgYiJK4moZuaP7Ia/92uDAe2jnZbHNQzFx4/ejNWT+3l9lEKnmHC/T1HAGaOIaj8WTArSarVISkqCVqtVuil1AvMWS0Ted3Vpghl33Yi3Huzm8lpSu2i0bxyG5pGeH3R6a5uSZ4u991B3r/vq0DjM42t/79emwvfaWTER+YSS398smBSk0+nQv39/6HQcrCgC8xZLZN4hRs/7aBYRjE8evRl/T3IuahY+1N1RKEWHGfFo79aO/3fn+8n9Sv7HTfHzzOAOFbaPj+wkqrk20SGKfn+zYFKQ2WzGokWLYDablW5KncC8xRKdd9MbPF9J6tcuGildr/cjCjZoMbBjI4QFXR+i/EJKR+x9aTD+1qO5Y9lLf+2Ezc/d7vWBnxov/aRsZS4xaSQgKtSI5+66scL3VNb7Y7xfHSMKBEWFRYp+f7NgUpAsyzh06BD/+hSEeYslOu+vJvQCADx4i/cZwLc+P9Dt8iC9FtoyE+MNjW+KhmFBTuvI1eiRZLFdf8/tNzbCludux2NebuNVRrtGobj9xkY13k5l/GNQe8wbcRMm9I8Vsj+qm9o1CvX4mtliUfT7mwWTBxwlR1S7NA4PwtH0IXj17i5uX9drr3/dBRs8X9ZvW+YLOzy44knyBt7YyHFb75uJvTyuN6H/9eLo1bu7eO2IXlmDOjX2yXYqI3VAHIYlNMX9ic2q9L5PHr25Un3EyqvoimGpDx727dW10tuy5FtVGSX60SMVTwOiJBZMHnCUHFFgadcoFPd0a4rxSRVfIUnu3BizhnbCstTebl9vE3W9oFo4pjvu6FhyhSehhfv5nB68pQUSW0Zi5wt34kjaXR77SFWHp7KrfpBv+3kYddX7VdG4fhD6tYvG7R0aVvm9i8fd4nWdiODqTfPgSeuoYJ9uLxDMGR7vdnnLBpXP6tm7bkRYJT+TMRUUykrfG2DBpCCdToeUlBR2QhaEeYultrwlScKc4TdhenLFHbQlScKYXq08TjXQKioE/33sFvwwpZ/La5MHtnVZpv+zf1N4sN5nV5ZKdW8V6fRzPZ2Ezc/eht9nDvLpfjRl2h1ahWKsUXjJ7UxPh90i0vMv3fB63h+BEaTX4p6Epl7XG31rS0QE6/HK3Z0rXrFcQ//StYnXbVfHC3/p6Jft+sM93dxfUdRIEo6mD8GmGbd53UbD+kHIfuHOSu9z0u1tERXq+odFrzaR7PRdV2m1WnTr1o3D3AVh3mIFct69YqPQrpHnaQbKqk6R9N/HvF9dmXR7W/Rr5zz/1Lh+sWhY3/utrKoq22+rfJ+uijwxIA6A5ww+Hev+9suKJ/p47UgPALIMJJWbgwsAZqY4FySzhnbC9n/egZG3tPS4rfaNwlyu2LVt6PkcJ3du7HV0pDsdGodh1K2e2+ELvr5V2SYqxOnniGA9/vPATQCAJuH1XEaguqOtxPksNeWOdtjy3O0uy+eO6ctpBeoqs9mM+fPnc9SWIMxbrLqYt+TxJlnV9IqN8rrObWVuc92f2AxBeg2se9f4Je/q9rONqKAPWP/20WjZIMTta12ahXudob2Uu2KsS7MbnH7WaKQKC9eZKR2xLLW3yxWvVhXcomvdoB7knNVOyz5+9GY8fWc7l3XvLnMVTKuRPF5x8xWjzsdFRbn2bv/nHehaJuMZyTUf8amRgJFlBmxIkoQGZWbWT+naGB8tfJej5OoqWZaRn5/PUVuCMG+xmHeJG7x0HK+usp3TX78/Httm9EfxhTOOvGu637Kzp1f3DNav4Laat49FZfpNuRuxOPrWlujSNNzre8vq3ioS9Qxa9G3rXKimdI3BPwa1x+eP34recQ2cXrP/+fkuK6ldNJ64zfW2bPq91wciVLYQrIl6Bq3XvnrV1SY6xOe3luvptdj7UjJeKTdg4+Myz4GUZSj+fcKCiYjIj8b28c/Iq/Ij/XRa56/zDc/c5rhtUh2yxx8qZ+od7Sp92xIAXr+vKwbe2BBf/znasPzxuCPLrh3fn0nugKrWJA1CS65klC8ENBoJqQPicGubBhXenqvIwBudO7xX5lZjTckyvPbVq4qys9z/d9yt1d7OU7fFue0bKEOGwU2B3LmKha+/sWDygNMKEJEvlJ0cU6QQow6dYupX6T39y15Vkq9fDWlf7rEwlemPUtp/qbJ6xUVh4Zge6OZmtOGsoZ3wQI/mmNA/FkPjYxyjAOMaus7ZI6Gk2BrevaSzsrfC4f7EZmgS7trvq225bT9xW5zzsj+LyL/3bQXA+bZbqeTOjTFnxE1Ot2r1Gk2Vb9y6O86KVPW8ezJ3RMkIuZeHdcGoW1tg+RO90TjcfR+22yoxEnLqne3x7/u7Vqst/r6NWRnqGL6iQqmpqUhNTUVRURHCw/1T5er1eowcORJ6vTJfqHUN8xarLuZd/ks9dYC4SR7d5R3XMAxP3RaHN38+WKltvPVgN3R+saRfzs2tIzHjrg54f90RTCo3+i9zSj/c9kaWx+28cndnr1dSSi9arXiiDy5eM1c471KT8CCM6dXK8bPZaofNLiNIr/X4i/S1++Lx2n2uQ+Ib1w/CmaJix8+DO7ufyyo22rlIiQo1InNqElpNXwkA6No8Au3aj0TLVq0xuEuM09WQDo3DsO/sJbx2X1eXgrlFFYbjl1qW2hsHzl7Ck5/twMkL1ypcd+9LgxGkL+nDFF5Pj8JrFsdrNwTrcfGqxeU94fX0MOg0yL9kclresUnJMUWGGPDyMPfzm1WVuztqlbnLJkmS4t8nvMKkII1Gg7i4OGg0PA0iMG+xmDcw9Y72Pt3e95P7YuCNDd3OEeUp76l3Vr4NoUYdsv7RH6/c3RmP9W2DDo3r4/X749EswvmXfJvoUGx7fiAGd2qMd0YnumzH3VW1tHvc/8Lt0iwcfdu6jnSriEGnQT1DSVFQ1Y72WdP6O8307umXtacZ3X+Y0g9zhscjuUsTxMXFQa/TIqFFhNPEqCuf6os9swe7zUFbjUsloUadx3m+yjOUaceNTZyvDJbdc0yZK0WTbm+Lnm2c+2gB1ZvV3pvSYq6sylxBkyRJ8e+TuvtNpgImkwlpaWkwmUzeV6YaY95i1cW8y19UqcpQ6sro0Lg+Fo7p4bYfSGXz3vys63Dtslo2CMHIW1q67VNSVoNQI94eneh0G68if7vZ+yNrPKno13b5rk7e6hGjTus0x09VS4J2jcJwT7dmMJvNHvPWaiS3hQEA3BobWe0ypDK1Vtltly8my86n1az8iEA3V76q0r+6sp/05uX2e3dCU7w9yrXoLs9msyv+fcKCSWF1aci1GjBvsepa3qNvbeWzbQ3pUvVJEyuTd8P67vugvPVgQpX350llRjIZKtGpuzIGVGMW8bI8tbUyxUJVPt9r/zEA/+9vCfhrfNMqjZT7/HH3naw9TdhZ0ZZfHNoJDUIMeH6I6zQAE/rHYWC55xJWpWCqShHYusy8TnNH3ORSRLkjScp/n7BgIiLykfBgfaVmqK6M16vZOdad0s7Kpb+n/3Wv6+2xv3St/PO+yrLbq9cmd7+0q8Oo0yKpXdVu6ZXl6Re93kcFXakWDYKREh/jdU6osnQaCbe6uVUGAHNG3OT085fje7pM+Fl+N7HRIdj6/ECM6+s60WQ9gxYLxzhPeOmPW3JAyZQMVaWG2UlYMBER+VB1R/P8PvNOdGgchrdHdQNQMm3Af8s8Ty1IX/2v6/fH9MBfb4rBt0/2BeD8uIt/3dulRjND67XVO+BWUe4nrXTHn78sy297ZkpHtGwQjBl3+W5YvjuRZSZl/GpCL7fTT2x+bqDTzzc2dh79Fmy4ftuve6tIdGnmPEDpxZROqFfu1qC7Yu1eDw9U9sctOaB6BZMacJScgvR6PSZMmFCnRhEpiXmLxby9G969GZZuPYl+7aJRP0iP7yc7P5+uV1wUfp1xOzJ+OYiHelb8OI2K8m7RIBj/eeD6LTe9VoNNM26DXUaFo9MqQ6fVYHxSLN7OOlSj7dRE2Rqg6rOtO//yfrh3azzc2/vcWb78fCe2jEDXZuFoEx2C577Z7Vhe/oG1afd0QePwIAzv3hyA9yKlfeMw7J41CLHPrvpzfffvKHtV9D8P3IRJn2dX/SCqoDr1kkYjKf59woJJQZIkITw83OezppJ7zFss5u3d7L92xm0dGqFPW8+PQmkcHoSXhnl5aCyqnre7uYeqq3UFjxAJVL7+fOu1Gpfbb+W33CDUiNl/9f5ZKMvTwANPrR4aH+MomPzVh6k6BZME5b9PeEtOQWazGenp6Yp3ZKsrmLdYdTXvqnydB+m1GNy5MUKNNf/bVcm8b2ntvp+N7/jvFk517w6JyFuJ4qDsPv3Vh+nBP58Zd2ubyEq/x2a3K/59woKJiIhqpFVUCNY83d/reuVnz/bmL12boGWDYPRvX/FIuLJlRVVrDLuKu9N4O5SqFlTV7W9WGVXZ8vikWHz22K344OHa9SQN3pLzICMjAxkZGbDZbEo3hYhI9SrTibtsJ+XKeOvBbrDbZb8+f81fV1Gqo/xRequHKpvK2D6tce6yqcqPWPFX32ytRkLPWH9flfQ9XmHyIDU1FTk5OdiyZYvSTSEiCgzVuMVUmWJJPSVPzZR/Tpu3K0gjepR0/nY3S3dZ//xLR/zngYQqX5GqSq5tois/6rG24hUmBRkMBkyfPh0Gg8H7ylRjzFusupq3Up1Sa0Pe/kqmJtut7lUUf+QdbNAh48FuSP3v9kqtP21wB/SOi0KP1pXvC1QVIVW4IjhpYDtYbDI+2njUL23RajSKf755hUlBsiyjsLCwUrPiUs0xb7GYt1hqyttTE165uzNCDFrMSPbtHEc1KVKrm5a/8m5yg/uZ2N0x6DQY0KGhTwYNlDX7r53wxIA4tG0U5n3lP4UadZg5tJNP21GWDOU/3yyYFGSxWLBgwQJYLK5PjybfY95i1dW85/05A/PMlI5C91sb8u4UE47fZw7C35NifbrdmlxhuqGaM7PXhryr66GerfD0IN8+OLqm7HZZ8bx5S46IyIf6tYvGgVeSff5ojUDh6wcSA5Xr51TenOHx2JNbhL4VzIGlBM5apl4smIiIfIzFkljaMrfkKnt3ruzjYeqi2jKfbKsGwThacBVDujTC5oPKtoX/qhWm5g6agYh5i8W8xaqrefvjqlVl1CTvyQPbAgDuK/ccN189vFkpTcIr3werMlY+1RffPtkHA9pFKf75lmQ19BBUsaKiIoSHh6OwsBD169f3/gYiojqq1fSVAIC5I+Jxd4K4KzhPfrYDK3aeBgDse3kwjLqqzfekBFmWcazgKlpEBrvcUnxv7WFEhhg8PhTXFx54dxN+PXweAHA0fYjPtnus4AoWrjuCT3895ljmy+37Q2V/z/MKk4LsdjsOHjwIu92udFPqBOYtFvMWqy7n/XCvVo7/r/rDd6unpnlLkoRWUSFu+1891q+NX4slAJjYPw4AkBIf49PttmwQUqlnH1aVGj7fLJgUZLFYsHjx4oAcZaFGzFss5i1WXc47KvT6rRq7oJsmtT3vfu2isfX5gXjzgZuUbkqlqCFvdvomIqJaLdjAX2XVERVq9Ps+GoQETr86fsqIiKhWiw4zYnpyBxi0GgTp1d9/qS74cnxPvLZ6H2am+G8yS9ECvmC6dOkSbrvtNlgsFthsNjz11FN47LHHlG4WgJJ72NHR0Yo9SqGuYd5iMW+x1JS3EkOJxvt4Mkxv1JS3GnVvFYmlf+/ps+2pIe+AHyVns9lgMpkQHByMq1evonPnztiyZQsaNKjck5I5So6IqHJKR8nNGR5f5+c5otqDo+T+pNVqERwcDAAoLi6GzWZTxbOWgJJibvv27bDZbEo3pU5g3mIxb7GYt1jMWyw15K14wbR27VqkpKQgJiYGkiRh2bJlLuvMnz8frVu3RlBQEBITE7Fu3boq7ePixYuIj49Hs2bNMG3aNERFqWMqfKvVihUrVsBqtSrdlDqBeYvFvMVSQ94dm5T8dZ7ULlqxNoiihrzrEjXkrXgfpitXriA+Ph6PPPII7r33XpfXlyxZgsmTJ2P+/Pno3bs33nnnHSQnJyMnJwctWrQAACQmJsJkMrm894cffkBMTAxuuOEG7Ny5E2fPnsU999yD++67D40aNfL7sRER1SUrnuyDYosNIUbFf7UQ+Zzin+rk5GQkJyd7fH3OnDkYO3Ysxo0bBwCYN28eVq9ejQULFiAtLQ0AsG3btkrtq1GjRujatSvWrl2L+++/3+06JpPJqfgqKipyWa7RaKDX62GxWJwm0dJqtdDpdDCbzU63/XQ6HbRarcvy0veWL/b0ej0kSYLZbHZabjAYIMuyyzwURqMRdrvdabkkSTAYDLDZbE4Veelyq9XqdGnTV8ek1+uh0WhUeUylbbJarTAajQFxTKXUep6A65/vQDkmtZ6n0nXKftaVOCYdAJPJFvDnqbT9JpMpYI5JzeepVNn2+OqYKjsZpuIFU0XMZjO2bduG6dOnOy2/8847sXHjxkpt4+zZs6hXrx7q16+PoqIirF27FhMmTPC4flpaGmbNmuWyfM6cOQgKKnlGTkJCAoYOHYrvvvsOO3bscKyTlJSE/v37Y+nSpTh06JBjeUpKCrp164aFCxciPz/fsXzEiBGIjY1FRkaG04dvwoQJCA8PR3p6ulMbpk+fjsLCQixYsMCxzGAwYMaMGTh8+DAWL17sWB4dHY2JEydi586dWLFihWN5bGwsRo0ahfXr1yMrK8ux3FfHNHLkSMTFxWHOnDmqPaZff/0Vt99+e0AdkxrP0+7duwEAc+fODZhjUvt5at26Nc6fP4+FCxcGzDGp/TzNnTs34I4JUN95Gjx4MMLCwhzfJ748plGjRqEyVDVKTpIkfPPNNxg2bBgA4PTp02jatCk2bNiAXr16OdZ79dVX8fHHH2Pfvn1et7lt2zaMHTsWsixDlmVMmDChwoLJ3RWm5s2bIy8vz9F7PlAreB4Tj4nHxGPiMfGY6toxXbt2DREREV5Hyan6ClOp8vMuyLJc6bkYEhMTkZ2dXel9GY1GGI2us5+6W67Xu3+qtKcnKpdfbrVasXbtWvTp0wc6neupcNcOSZLcLtdoNG6Xa7VaaLWuE7npdDq3+6zpMZVy1xZPy0Udk9Vqxfr169GnT58K216bjqk8NR2TLMvYtGmTy+e7Nh+Tms+T1WpFVlYW+vTpEzDHVEqN56ns90npLaPafkzuqOWYrFYrNmzY4Pb3ZU2PyV0faHcUHyVXkaioKGi1Wpw5c8ZpeV5ent87bWdkZKBjx47o0aOH3/Zhs9mQlZXFYamCMG+xmLdYzFss5i2WGvJWdcFkMBiQmJiIzMxMp+WZmZlOt+j8ITU1FTk5OdiyZYtf90NERETqp/gtucuXL+PgwYOOn48cOYLs7GxERkaiRYsWmDp1KkaPHo3u3bujZ8+eePfdd3H8+HGMHz9ewVYTERFRXaJ4wbR161YMGDDA8fPUqVMBAGPGjMFHH32EESNGoKCgALNnz0Zubi46d+6MVatWoWXLln5tV0ZGBjIyMvx6+U+j0SAhIcFpyCT5D/MWi3mLxbzFYt5iqSFvVY2SUyM+S46IiChw8VlytYDFYsHy5ctdhmGSfzBvsZi3WMxbLOYtlhryZsHkgYhRcna7HTt27Kj0LKNUM8xbLOYtFvMWi3mLpYa8WTB5wFFyREREVErxTt9qV9rFq/SZcr5kMplQXFyMoqIij5ODke8wb7GYt1jMWyzmLZY/8y79/e6tSzc7fXtx8uRJNG/eXOlmEBERkR+dOHECzZo18/g6CyYv7HY7Tp8+jbCwsEo/jqWySp9Td+LECY7AE4B5i8W8xWLeYjFvsfyZtyzLuHTpEmJiYiqctoC35LzQaDQVVpy+UL9+ff6DE4h5i8W8xWLeYjFvsfyVd3h4uNd12OmbiIiIyAsWTEREREResGBSkNFoxIsvvsgRFoIwb7GYt1jMWyzmLZYa8manbyIiIiIveIWJiIiIyAsWTEREREResGAiIiIi8oIFExEREZEXLJgUMn/+fLRu3RpBQUFITEzEunXrlG6S6qWlpaFHjx4ICwtDw4YNMWzYMOzbt89pHVmWMXPmTMTExKBevXro378//vjjD6d1TCYTnnzySURFRSEkJARDhw7FyZMnnda5cOECRo8ejfDwcISHh2P06NG4ePGivw9R1dLS0iBJEiZPnuxYxrx969SpUxg1ahQaNGiA4OBg3HTTTdi2bZvjdebtO1arFc8//zxat26NevXqoU2bNpg9ezbsdrtjHeZdfWvXrkVKSgpiYmIgSRKWLVvm9LrIbI8fP46UlBSEhIQgKioKTz31FMxmc9UPSibhPv/8c1mv18vvvfeenJOTI0+aNEkOCQmRjx07pnTTVG3QoEHyhx9+KO/evVvOzs6WhwwZIrdo0UK+fPmyY5309HQ5LCxM/uqrr+Rdu3bJI0aMkJs0aSIXFRU51hk/frzctGlTOTMzU96+fbs8YMAAOT4+XrZarY51Bg8eLHfu3FneuHGjvHHjRrlz587yX/7yF6HHqyabN2+WW7VqJXft2lWeNGmSYznz9p3z58/LLVu2lB9++GH5t99+k48cOSL/+OOP8sGDBx3rMG/fefnll+UGDRrI3377rXzkyBH5iy++kENDQ+V58+Y51mHe1bdq1Sr5ueeek7/66isZgPzNN984vS4qW6vVKnfu3FkeMGCAvH37djkzM1OOiYmRn3jiiSofEwsmBdx8883y+PHjnZZ16NBBnj59ukItqp3y8vJkAHJWVpYsy7Jst9vlxo0by+np6Y51iouL5fDwcPntt9+WZVmWL168KOv1evnzzz93rHPq1ClZo9HI33//vSzLspyTkyMDkH/99VfHOps2bZIByHv37hVxaKpy6dIluW3btnJmZqaclJTkKJiYt28988wzcp8+fTy+zrx9a8iQIfKjjz7qtOyee+6RR40aJcsy8/al8gWTyGxXrVolazQa+dSpU451PvvsM9loNMqFhYVVOg7ekhPMbDZj27ZtuPPOO52W33nnndi4caNCraqdCgsLAQCRkZEAgCNHjuDMmTNO2RqNRiQlJTmy3bZtGywWi9M6MTEx6Ny5s2OdTZs2ITw8HLfccotjnVtvvRXh4eF18hylpqZiyJAhGDhwoNNy5u1by5cvR/fu3XH//fejYcOGSEhIwHvvved4nXn7Vp8+ffDTTz9h//79AICdO3di/fr1uOuuuwAwb38Sme2mTZvQuXNnxMTEONYZNGgQTCaT0+3uyuDDdwU7d+4cbDYbGjVq5LS8UaNGOHPmjEKtqn1kWcbUqVPRp08fdO7cGQAc+bnL9tixY451DAYDIiIiXNYpff+ZM2fQsGFDl302bNiwzp2jzz//HNu3b8eWLVtcXmPevnX48GEsWLAAU6dOxbPPPovNmzfjqaeegtFoxEMPPcS8feyZZ55BYWEhOnToAK1WC5vNhldeeQV/+9vfAPDz7U8isz1z5ozLfiIiImAwGKqcPwsmhUiS5PSzLMsuy8izJ554Ar///jvWr1/v8lp1si2/jrv169o5OnHiBCZNmoQffvgBQUFBHtdj3r5ht9vRvXt3vPrqqwCAhIQE/PHHH1iwYAEeeughx3rM2zeWLFmCRYsW4b///S86deqE7OxsTJ48GTExMRgzZoxjPebtP6Ky9VX+vCUnWFRUFLRarUtlm5eX51IFk3tPPvkkli9fjl9++QXNmjVzLG/cuDEAVJht48aNYTabceHChQrXOXv2rMt+8/Pz69Q52rZtG/Ly8pCYmAidTgedToesrCy8+eab0Ol0jiyYt280adIEHTt2dFp244034vjx4wD4+fa1f/zjH5g+fToeeOABdOnSBaNHj8aUKVOQlpYGgHn7k8hsGzdu7LKfCxcuwGKxVDl/FkyCGQwGJCYmIjMz02l5ZmYmevXqpVCragdZlvHEE0/g66+/xs8//4zWrVs7vd66dWs0btzYKVuz2YysrCxHtomJidDr9U7r5ObmYvfu3Y51evbsicLCQmzevNmxzm+//YbCwsI6dY5uv/127Nq1C9nZ2Y7/unfvjpEjRyI7Oxtt2rRh3j7Uu3dvl2ky9u/fj5YtWwLg59vXrl69Co3G+VegVqt1TCvAvP1HZLY9e/bE7t27kZub61jnhx9+gNFoRGJiYtUaXqUu4uQTpdMKvP/++3JOTo48efJkOSQkRD569KjSTVO1CRMmyOHh4fKaNWvk3Nxcx39Xr151rJOeni6Hh4fLX3/9tbxr1y75b3/7m9uhqs2aNZN//PFHefv27fJtt93mdqhq165d5U2bNsmbNm2Su3TpEvDDgCuj7Cg5WWbevrR582ZZp9PJr7zyinzgwAF58eLFcnBwsLxo0SLHOszbd8aMGSM3bdrUMa3A119/LUdFRcnTpk1zrMO8q+/SpUvyjh075B07dsgA5Dlz5sg7duxwTJ8jKtvSaQVuv/12efv27fKPP/4oN2vWjNMK1CYZGRlyy5YtZYPBIHfr1s0xNJ48A+D2vw8//NCxjt1ul1988UW5cePGstFolPv16yfv2rXLaTvXrl2Tn3jiCTkyMlKuV6+e/Je//EU+fvy40zoFBQXyyJEj5bCwMDksLEweOXKkfOHCBQFHqW7lCybm7VsrVqyQO3fuLBuNRrlDhw7yu+++6/Q68/adoqIiedKkSXKLFi3koKAguU2bNvJzzz0nm0wmxzrMu/p++eUXt9/XY8aMkWVZbLbHjh2ThwwZIterV0+OjIyUn3jiCbm4uLjKxyTJsixX7ZoUERERUd3CPkxEREREXrBgIiIiIvKCBRMRERGRFyyYiIiIiLxgwURERETkBQsmIiIiIi9YMBERERF5wYKJiIiIyAsWTERENbRmzRpIkoSLFy8q3RQi8hMWTEREREResGAiIiIi8oIFExHVerIs47XXXkObNm1Qr149xMfH48svvwRw/XbZypUrER8fj6CgINxyyy3YtWuX0za++uordOrUCUajEa1atcIbb7zh9LrJZMK0adPQvHlzGI1GtG3bFu+//77TOtu2bUP37t0RHByMXr16Yd++ff49cCIShgUTEdV6zz//PD788EMsWLAAf/zxB6ZMmYJRo0YhKyvLsc4//vEP/Pvf/8aWLVvQsGFDDB06FBaLBUBJoTN8+HA88MAD2LVrF2bOnIl//vOf+Oijjxzvf+ihh/D555/jzTffxJ49e/D2228jNDTUqR3PPfcc3njjDWzduhU6nQ6PPvqokOMnIv+TZFmWlW4EEVF1XblyBVFRUfj555/Rs2dPx/Jx48bh6tWrePzxxzFgwAB8/vnnGDFiBADg/PnzaNasGT766CMMHz4cI0eORH5+Pn744QfH+6dNm4aVK1fijz/+wP79+9G+fXtkZmZi4MCBLm1Ys2YNBgwYgB9//BG33347AGDVqlUYMmQIrl27hqCgID+nQET+xitMRFSr5eTkoLi4GHfccQdCQ0Md/33yySc4dOiQY72yxVRkZCTat2+PPXv2AAD27NmD3r17O223d+/eOHDgAGw2G7Kzs6HVapGUlFRhW7p27er4/yZNmgAA8vLyanyMRKQ8ndINICKqCbvdDgBYuXIlmjZt6vSa0Wh0KprKkyQJQEkfqNL/L1X24nu9evUq1Ra9Xu+y7dL2EVHtxitMRFSrdezYEUajEcePH0dcXJzTf82bN3es9+uvvzr+/8KFC9i/fz86dOjg2Mb69eudtrtx40a0a9cOWq0WXbp0gd1ud+oTRUR1C68wEVGtFhYWhqeffhpTpkyB3W5Hnz59UFRUhI0bNyI0NBQtW7YEAMyePRsNGjRAo0aN8NxzzyEqKgrDhg0DAPzf//0fevTogZdeegkjRozApk2b8NZbb2H+/PkAgFatWmHMmDF49NFH8eabbyI+Ph7Hjh1DXl4ehg8frtShE5FALJiIqNZ76aWX0LBhQ6SlpeHw4cO44YYb0K1bNzz77LOOW2Lp6emYNGkSDhw4gPj4eCxfvhwGgwEA0K1bNyxduhQvvPACXnrpJTRp0gSzZ8/Gww8/7NjHggUL8Oyzz2LixIkoKChAixYt8OyzzypxuESkAI6SI6KAVjqC7cKFC7jhhhuUbg4R1VLsw0RERETkBQsmIiIiIi94S46IiIjIC15hIiIiIvKCBRMRERGRFyyYiIiIiLxgwURERETkBQsmIiIiIi9YMBERERF5wYKJiIiIyAsWTERERERe/H+pc+sFxp2ZBAAAAABJRU5ErkJggg==",
+      "text/plain": [
+       "<Figure size 600x400 with 1 Axes>"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "# plot training process\n",
+    "fig, ax = plt.subplots(figsize=(6, 4))\n",
+    "ax.set_xlabel(\"epoch\")\n",
+    "ax.plot(losses, \"C0\")\n",
+    "ax.set_ylabel(criterion.__class__.__name__)\n",
+    "ax.grid(color=\"gray\", linestyle=\"dashed\")\n",
+    "ax.set_yscale(\"log\")\n",
+    "fig.tight_layout()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Calibration Results"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 19,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "image/png": "iVBORw0KGgoAAAANSUhEUgAAAnYAAAHWCAYAAAD6oMSKAAAAOXRFWHRTb2Z0d2FyZQBNYXRwbG90bGliIHZlcnNpb24zLjkuMiwgaHR0cHM6Ly9tYXRwbG90bGliLm9yZy8hTgPZAAAACXBIWXMAAA9hAAAPYQGoP6dpAAB3pElEQVR4nO3dfVxUZf4//teZO0xF8i7NArzP1Mw7slELlaxftZa22tZ6l9mNWmGGK5j1MbcQcENc2xVTW9rSttTNvrrdbKaId5iIaKltGipY6appaGvO3Tm/P4Y5zDADDMpwrjO8no+Hj12uubuOr4benXPe1yUpiqKAiIiIiHTPoPUEiIiIiKhusLAjIiIiChMs7IiIiIjCBAs7IiIiojDBwo6IiIgoTLCwIyIiIgoTLOyIiIiIwgQLOyIiIqIwYdJ6AldDlmX8+OOPiIyMhCRJWk+HiIiIqM4pioKLFy+iXbt2MBiqPyen68Luxx9/RHR0tNbTICIiIgq5EydO4MYbb6z2Obou7CIjIwG4D7RZs2Yh+xxZlvHTTz+hZcuWNVbKVH+Yi5iYi5iYi5iYi5hEy+XChQuIjo5W657q6Lqw81x+bdasWUgLO0VRcM0118BisfCSr0CYi5iYi5iYi5iYi5hEzSWYuWhfhuqA3W5Heno67Ha71lMhL8xFTMxFTMxFTMxFTHrOhYUdERERUZhgYUdEREQUJnR9j12wXC4XHA7HFb/ebrejSZMmsNlsUBSlDmdGV8pisWg9BSIiIuFIio4rlQsXLiAqKgplZWUBmycURcGpU6fw888/X/VnKYoi1A2UDZ3BYED79u0BQLibWxs6RVFgt9uZi2CYi5iYi5hEy6WmesdbWJ+x8xR11113HRo3bnzF4SiKAqfTCZPJJETADZ1nYeqTJ0/immuuQevWrZmLQBRFQVlZGVq1asVcBMJcxMRcxKTnXMK2sHO5XGpR17Jly6t6L1mWcf78ebRt21aI9WwIaN26NX744Qf84x//wAsvvICIiAitp0TlHA4HsrOzkZKSwlwEwlzExFzEpOdcwrZK8dxT17hxY41nQqHgucfObDZrPBMiIiJxhG1h56G3U6gUHOZKRETkL+wLu7rCQkJMPGMnJnYti4m5iIm5iEmvuYRtV+zly5dx7NgxdOjQAY0aNdJohvXnlVdewUcffYR9+/YF/ZohQ4agd+/eWLRokabzuBINLV8iImq4atMVyzN2QVAUBZcvXxZ6DbuZM2di06ZNtXrNhx9+iFdffTVEMwo9RVFQUlICWZa1ngp5kWUZ3333HXMRDHMRE3MRU3W5ZG08jMWbjgR83eJNR5C18XCop1ctFnbV8ISnKArOnTvnU9iJEB5QsRRL06ZNa93926JFC0RGRoZoZvVjw4YNV7X4NNU9h8OBVatWMRfBMBcxMRcxVZfLwBPL4Nic7lfcLd50BI7N6Rh4Yll9TTMgFnbVMBokLNx4GG9s/s5nfPGmI1i48TCMhtDcd2ez2ZCYmIjrrrsOjRo1wuDBg1FQUAAA2LJlCyRJwr///W/0798fERER2LZtG1555RX07t1bfQ+n04nExERce+21aNmyJZKTkzFx4kSMHDlSfc6QIUPw/PPPqz+3b98e8+fPx+OPP47IyEjExMRg2TLff0CTk5PRtWtXNG7cGB07dsTLL7/MX0hERNRgDOh0HZLMa32KO09Rl2ReiwGdrtN0fizsqpGY0AUvDO+KrC+OIGf3KQAVRd0Lw7siMaFLSD531qxZ+Oc//4m///3v2Lt3Lzp37ox77rkH586d83lOWloavvnmG/Tq1cvvPTIyMrBq1Srk5ORgx44duHDhAj766KMaPzszMxP9+/dHUVERpk2bhqlTp+I///mP+nhkZCTefvttHDp0CH/+85+xfPlyZGVl1clxExERCS9+FjB0jlrcdZ3zqVrUYegc9+MaCtsFiutKYkIXKIqCrC+O4O8Fp2B3KSEt6v73v/8hOzsbb7/9Nu69914AwPLly7Fx40a89dZbiIuLAwD88Y9/xPDhw6t8nzfeeAOzZ8/GqFGjAAB/+ctf8Mknn9T4+ffddx+mTZsGwH12LisrC1u2bEG3bt0AAC+99JL63Pbt2yMpKQkffPABZs3S5h/kFi1asGNZMJIkcTcQATEXMTEXMdWYS3nxlpSbimeVjxAhOYUo6gCesQvK9Lu6wmI0wO5SYDEaQlbUAUBxcTEcDgcGDRqkjpnNZtx222345ptv1LH+/ftX+R5lZWX473//i9tuu00dMxqN6NevX42f7332T5IktG3bFqdPn1bH1q5di8GDB6Nt27Zo2rQpXn75ZZSWlgZ9fHVJkiT8/ve/121LeriyWCyYNm0acxEMcxETcxFTMLksdo6CTTEhQnLCppiw2DmqHmdYNRZ2QfjzF4dhd8nlxZ1cZTdMXfA0aFT+rwRFUXzGmjRpUuN7BXqPmlReF06SJLUraNeuXXjkkUdw77334l//+heKioowZ84c2O32Gt83FBRFwcGDB+FyuTT5fArM5XJh7969zEUwzEVMzEVMNeXiuacuQnICRgsiJGfAhgotsLCrweJNR5D1xRE8efv1+M+r9+CF4V2xsJpW56vVuXNnWCwWbN++XR1zOBzYs2cPbr755qDeIyoqCm3atMHu3bvVMZfLhaKioqua244dOxAbG4s5c+agf//+6NKlC0pKSq7qPa9Wbm4unE6npnMgX06nExs2bGAugmEuYmIuYqouF+9GCQydA7x8xueeO62LO95jVw1Po8SMu7pgTPemAKBehl1YvtRJXV+WbdKkCaZOnYo//OEPaNGiBWJiYrBgwQJcunQJkydPxv79+4N6n+eeew5paWno3LkzunXrhjfeeAPnz5+/qvs4OnfujNLSUrz//vuIi4vDxx9/jHXr1l3x+xEREelN/5LlGFi5UcLrnrudJS0BLNBsfizsquGS3Y0Szw7thFOnTqnjnmLOJYdmweL09HTIsozx48fj4sWL6N+/P/7973+jefPmQb9HcnIyTp06hQkTJsBoNOKpp57CPffcA6PReMXzevDBBzFjxgw8++yzsNlsuP/++/Hyyy/jlVdeueL3JCIiElXhO7MhmcywTspQxwZ2aA50moP8oz8B382EdfLr7gfKi7uBsraX1bmlWBBkWcb58+fRvHlzGAz6vHotyzJuvvlmPPzww7rebcLj8uXLOHr0KA4cOICRI0fyxmOB2O12rF69Gg8//DBzEQhzERNzEZMnl462/Rh4YhnyY6f4FHf5Ocmwliz1Gw+V2mwpxsIuTJWUlODzzz9HfHw8bDYb/vKXvyAnJwf79+8P+l49kTX0fImIqH5ULuLqu6gDuFdsnVMUBRcvXhR6r9jKDAYD3n77bcTFxWHQoEH4+uuv8cUXX4RFUeehKAp2797Nm44F43Q6sWXLFuYiGOYiJuYiJu9crJMy3EVcyVLY57as96KutljYBUGPhV10dDR27NiBsrIyXLhwATt37sSdd96p9bTq3O7du7lMgGBcLhfy8vKYi2CYi5iYi5gq52KdlAG7YoJFcsKumIQt6gAWdkRERETIqmYpszWZz6lFnUVyIj8nuZ5nFzwWdkRERNTgGQ1SwHVq12Q+hzEX38GayAmwzPtJvSwranHH5U6C1LhxY62nQAF0795dt53K4cpgMKBPnz7MRTDMRUzMRRyJhrWIu+lnPLrRfSm2T58++H9vJOHhX97FAUtvjOnbDgDKGyhQXtxBuMuyLOyCYDAYcO2112o9DapEkiQMGzbMbxs00pbZbMYDDzyg9TSoEuYiJuYiEIMR1pKl+MdNwKObAYvRjGnS/3CgcW/0tO8DDPerT/UUd9B4zbpA+J8IQZBlGT///LO6ZyqJQVEUbN68GQ6HQ+upkBeHw4H169czF8EwFzExF4HEzwKGzoG1ZCmeN6+D3SUDktFd1HnvMlHOOimjYnFigbCwC9KlS5e0nkJQXnnlFfTu3Vv9+bHHHsPIkSPVn4cMGYLnn3++3udVW5WPoyqHDh1iwS0YWZZRVFTEXATDXMTEXLRRZaNE/CysiZyA541r8G2E+3/zY6f4FXUiY2EX5v785z/j7bffrpfPCrYYIyIi0tLAE8vg2JzuV9z9fvkulJ67BBcMiJCccEpmPPrtnVV2y4qIhV2Yi4qKuur7A+12e91MhoiISAADOl2HJPNan+Lu98t3od/x5Ugyr4URMpwwwqQ48I+btgbslhUVC7vq5KYBeQsgSRIiIyMhSVLFY3kL3I+HgCzLyMjIQOfOnREREYGYmBikpqYCAJKTk9G1a1c0btwYHTt2xMsvv1ztvRmVL8UC7hW1n332WVx77bVo2bIlXnrpJZ/Fl9u3b4/XXnsNjz32GKKiovDkk0/W+Nlvv/025s2bh/3790OSJEiSpJ4pLCsrw1NPPYXrrrsOzZo1w7Bhw7B//36fOaWnp6NNmzaIjIzE5MmTcfny5aD+rm677TYYjcagnkv1w2g0Ij4+nrkIhrmIiblopPx+Ok9x13XOp2pRBwCu+NnYPuRDuOJnlzdUbIVL1scmBeyKrY7BCOSmQgIQ6X19PW8BkJvqvpkyBGbPno3ly5cjKysLgwcPxsmTJ/Gf//wHABAZGYm3334b7dq1w9dff40nn3wSkZGRmDUr+Ov/f//73zF58mR8+eWX2LNnD5566inExsaqBRwA/OlPf8LLL7+Ml156SR2r7rN/97vf4cCBA/jss8/wxRdfAHCfLVQUBffffz9atGiBTz75BFFRUXjzzTeRkJCAw4cPo0WLFli9ejXmzp2Lv/71r7jjjjvw7rvvYvHixejYsWO1xyFJEm677TaYTPzHWCQmkwlDhgzRehpUCXMRE3PRUPm/15NyU/Gs8hEipPJt3YbOgTF+FoYAAIYABgOsuamwdmwJQAf32ik6VlZWpgBQysrK/B779ddflUOHDim//vrr1X3IlgxFmdtM+d8ncxWXy6X+rGzJuLr3rcKFCxeUiIgIZfny5UE9f8GCBUq/fv3Un+fOnavceuut6s8TJ05UHnzwQfXn+Ph45eabb1ZkWVbHkpOTlZtvvln9OTY2Vhk5cuRVf7aiKMqmTZuUZs2aKZcvX/YZ79Spk/Lmm28qiqIoVqtVmTJlis/jAwYM8Hsvb7/++qty8OBB5YMPPlBsNluNc6X6Y7PZlHfffZe5CIa5iIm5aOvPXxxWLv9fC0WZ20xx/F+UsvNvsxRFCZDLlgxF2Txfs3lWV+9UxlMdNYmfBVlR0HjLfCh7/gq47AHbnuvKN998A5vNhoSEhICPr127FosWLcJ3332HX375BU6nE82aNavVZ9x+++0+l5WtVisyMzPhcrnUywH9+/evk88uLCzEL7/8gpYtW/qM//rrryguLlaPecqUKT6PW61W5Obm1ngspaWlutrDtyFQFAXFxcXMRTDMRUzMRTuLNx2BY3M6IsxOwGiByWXHzu/OomDTETw9OMY3F3bFhpk7/wDFYIbksgNGS0gDvuaaa6p8bNeuXXjkkUdw77334l//+heKioowZ86ckDQ3NGnSpE4+W5ZlXH/99di3b5/Pn2+//RZ/+MMf6nzeRERENfEUdUnmte6TNS+f8bnn7q9bjmo9xSvGM3bB2PonSLIDitHiLu7yFoSsuOvSpQuuueYabNq0CU888YTPYzt27EBsbCzmzKm4t6+kpKTWn7Fr1y6/n7t06VLtzbvBfLbFYoHL5bsKd9++fXHq1CmYTCa0b98+4HvffPPN2LVrFyZMmFDlHImIiOpK/5LlGOgp6jz/Pve65277iebYhEgNZ3jlWNjVJG8BDFvmwz7oDzDfNQfY+id34wQQkuKuUaNGSE5OxqxZs2CxWDBo0CCcOXMGBw8eROfOnVFaWor3338fcXFx+Pjjj7Fu3bpaf8aJEyfwwgsv4Omnn8bevXvxxhtvIDMzs9rXBPPZ7du3x7Fjx7Bv3z7ceOONiIyMxF133QWr1YqRI0ciIyMDN910E3788Ud88sknGDlyJPr374/p06dj4sSJ6N+/PwYPHoxVq1bh4MGDNTZPAMDQoUPZPCEYk8mEESNGMBfBMBcxMRdtDOzQHOgU4Laq8p8Huhxo3PdefeYSwnv9Qi7kzRNVNUqEuIHC5XIpr732mhIbG6uYzWYlJiZGmT/ffdPmH/7wB6Vly5ZK06ZNld/97ndKVlaWEhUVpb42mOaJadOmKVOmTFGaNWumNG/eXElJSfFppoiNjVWysrL85lXTZ1++fFn57W9/q1x77bUKACUnJ0dRFHdDyHPPPae0a9dOMZvNSnR0tDJ27FiltLRUfW1qaqrSqlUrpWnTpsrEiROVWbNm1dg8USfNMURERIKrTfOEpCj6vWPzwoULiIqKQllZmd9N/JcvX8axY8fQoUMHNGrU6Mo+IDcNMBgh3zETZ8+eRatWrWAwlN+WmLfAvfnv0NlXeRR0JS5fvoyjR49i165dGDduHCwWi9ZTonJ2ux0rVqzAE088wVwEwlzExFzEJFou1dU7lenwHGM98hRtsgyn0+n7mI46ZMLZuXPn2E0mGEVRcObMGeYiGOYiJuYiJj3nwq5YIiIiClv5b81Efk5y4MdykpH/1sx6nlFosbAjIiKi8GUwwlqy1K+4y89JhrVkqXuXqTDCwi4IkiShRYsWvnvFkhBGjBgBs9ms9TTIi9lsxtixY5mLYJiLmJhL6FknZSA/dopPcecp6vJjp8A6KcPvNXrOhc0TpEvMl4iIasNTzNkVEyySs8qiTkS1aZ4I+zN2dVG3yrKMkydPQpblOpgR1QVFUaAoCt58803YbDatp0NebDYb0tLSmItgmIuYmEv9sU7KUIs6u2KqtqjTcy5hW9h5Tp9eunSpTt5Pxyc2w5JnK7O6ypfqVii2uaOrx1zExFzqR35OslrUWSRnlQ0VHnrNJWyXOzEajbj22mtx+vRpAEDjxo2v+B45uXy5k8uXL1esY0eakWUZZ86cQaNGjXT7xSMiovpT+Z469ecc6OZybLA0LeycTideeeUVrFq1CqdOncL111+Pxx57DC+99FKdFFBt27YFALW4u1KKoqCsrAy//PILGygEYTAY1HyJiIiqEqhRwl3cISyLO02bJ1JTU5GVlYW///3v6NGjB/bs2YNJkybhtddew/Tp02t8fbA3E7pcLjgcjiuepyzLOH/+PJo3b84zdoLwrATutyMIaU6WZeYiIOYiJuYSevlvzXQveRKgeMvPSQZkF6yTX/cZFy2X2jRPaFrY/eY3v0GbNm3w1ltvqWO//e1v0bhxY7z77rs1vr42B3o1FEWB3W6HxWLhGTuBMBcxMRcxMRcxMRcxiZaLbrpiBw8ejE2bNuHw4cMAgP3792P79u247777tJyWH7vdjvT0dN7PJRjmIibmIibmIibmIiY956LpPXbJyckoKytDt27dYDQa4XK5kJqaikcffTTg8202m0/r8YULF/zGDQYDzGYzHA6Hz/IkRqMRJpMJdrvdp8PVZDLBaDT6jZvNZhgMBp/3ttlsMJvNkCTJL2yLxQJFUfwu+UZERECWZZ9xSZJgsVjgcrl89qD1jDudTrhcLnU8FMfkTa/H5H0c4XJMnrnrOScP7/nr/ZjCISfv32PhckzhkJP3vMLlmAD95+ThPR+tjylYmhZ2H3zwAVauXIn33nsPPXr0wL59+/D888+jXbt2mDhxot/z09LSMG/ePL/xhQsXqovU9unTBw888AA+/fRTFBUVqc+Jj4/HkCFDsHr1ahQXF6vjI0aMQN++fbFixQqcOXNGHR87diw6d+6MhQsXqn/5WVlZmDp1KqKiopCenu4zh5SUFJSVlSE7O1sds1gsmD17No4ePYpVq1ap461bt8a0adOwf/9+bNiwQR3v1KkTxo0bh+3btyMvL08dD+UxAdD1MXmE0zHpPacePXoAcH9fwuWYwimnrKyssDsmQN85eYTTMek9p3vuuQeA7+8xLY/p2LFjCJam99hFR0cjJSUFzzzzjDr22muvYeXKlfjPf/7j9/xAZ+yio6Nx+vRp9ZpzqM7YZWVlYcaMGWjatCn/i0iQY/LkkpKSgsr0ekyeues5J6fTifT0dMyYMQMRERFhcUzhkNPly5fV32NNmjQJi2MKh5y8f49JkhQWxwToPydZlv1+j2l5TD///DOaN28ufvNEy5Yt8dprr2Hq1KnqWFpaGnJyctT77qrD5omGjbmIibmIibmIibmISbRcdNM8MWLECKSmpuLjjz/G8ePHsW7dOixcuBCjRo3Sclp+POvYcfcJsTAXMTEXMTEXMTEXMek5F00LuzfeeAOjR4/GtGnTcPPNN2PmzJl4+umn8eqrr2o5LT8OhwPZ2dlXtRYe1T3mIibmIibmIibmIiY956Jp80RkZCQWLVqERYsWaTkNIiIiorCg/XLKRERERFQnWNgFybOFFYmFuYiJuYiJuYiJuYhJr7lo2hV7teqrK5aIiIhIK7rpitULWZbx3Xff1WrlZwo95iIm5iIm5iIm5iImPefCwi4IDocDq1at0mV3TDhjLmJiLmJiLmJiLmLScy4s7IiIiIjCBAs7IiIiojDBwi4IkiShdevWQmwrQhWYi5iYi5iYi5iYi5j0nAu7YomIiIgExq7YOuZyubB37164XC6tp0JemIuYmIuYmIuYmIuY9JwLC7sgOJ1ObNiwAU6nU+upkBfmIibmIibmIibmIiY958LCjoiIiChMsLAjIiIiChMs7IIgSRI6deqky+6YcMZcxMRcxMRcxMRcxKTnXNgVS0RERCQwdsXWMafTiS1btujyJspwxlzExFzExFzExFzEpOdcWNgFweVyIS8vT5dtz+GMuYiJuYiJuYiJuYhJz7mwsCMiIiIKEyzsiIiIiMIEC7sgGAwG9OnTBwYD/7pEwlzExFzExFzExFzEpOdc2BVLREREYSH/rZmAwQjrpAz/x3KSAdkF6+TXNZjZ1WFXbB1zOBxYv349HA6H1lMhL8xFTMxFTMxFTMyljhmMsJYsdRdxXvJzkmEtWQoYjEG9jZ5zYWEXBFmWUVRUBFmWtZ4KeWEuYmIuYmIuYmIudcs6KQP5sVN8ijtPUZcfOyXgmbxA9JyLSesJEBEREdUV66QM5OcA1pKlsM9dAavkrFVRp3c8Y0dERERhxTopA3bFBIvkhF0xNZiiDmBhFxSj0Yj4+HgYjcFdm6f6wVzExFzExFzExFxCIz8nWS3qLJLT7567mug5F3bFEhERUdiofE/dldxjJxp2xdYxu92OlStXwm63az0V8sJcxMRcxMRcxMRc6lagIi5QQ0VN9JwLmyeCoCgKiouLoeOTm2GJuYiJuYiJuYiJudQx2RXwzJynoQJycHu/6jkXFnZEREQUFqpbfFivl2Fri5diiYiIiMIEC7sgmEwmjBgxAiYTT3CKhLmIibmIibmIibmISc+5sCuWiIiISGDsiq1jdrsdS5Ys0WV3TDhjLmJiLmJiLmJiLmLScy4s7IKgKArOnDmjy+6YcMZcxMRcxMRcxMRcxKTnXFjYEREREYUJFnZERESkL7lpQN6CwI/lLXA/3kCxsAuC2WzG2LFjYTabtZ4KeWEuYmIuYmIuYmIuQQhQxO08dh7ITQX+PsK3iMtbAOSmuh+/CnrOhYVdEAwGAzp37gyDgX9dImEuYmIuYmIuYmIuNVOLOK/ibk/sk9jh6g4c24rSfV+4B8uLukzHaOyJffKqPlPPuehvxhqw2WxIS0uDzWbTeirkhbmIibmIibmIibnUbE/sk8h0jPYp7hJN6zDIeAg7XN0RU7YHeLW1WtSZh6UgMaHLVX2mnnNhYRckPbY8NwTMRUzMRUzMRUzMpXqJCV1gHpZSUdx5FXF/jcmCTTEBLjtsiqlOijoPvebCwo6IiIiE5inuKhdx73XdigjJCZtiQoTkRKJpndZT1RwLOyIiIhJeommdbxH3/QvqmbtbnCv9Ltc2VNxSLAiyLOPs2bNo1aqVLm+kDFfMRUzMRUzMRUzMJUhejRFvYjRyDH9U77ErHPIOEhO6YPGmI3BsTkeSeS0wdA4QP+uKP060XLilWB2TJAlRUVGQJEnrqZAX5iIm5iIm5iIm5hIEr6LOPCwFh1Pvxalr+2KHqzsGGQ+pl1+978X7svj0VX2knnNhYRcEu92O9PR03d5IGa6Yi5iYi5iYi5iYS82+LD7t1+1a2ms6/hqT5VfEeYq7ndFPXdVn6jkXk9YTICIiIqrKzuinYI6VfLpdZwzvCgBYvKkldsoKBng9v666YvWKhR0REREJy1PEBdLQi7hAeCmWiIiIKEywKzYIiqLAbrfDYrHo8kbKcMVcxMRcxMRcxMRcxCRaLuyKrWOKoqCsrAw6roHDEnMRE3MRE3MRE3MRk55zYWEXBIfDgezsbDgcDq2nQl6Yi5iYi5iYi5iYi5j0nAsLOyIiIqIwwcKOiIiIKEywsAuSxWLRegoUAHMRE3MRE3MRE3MRk15zYVcsERERkcDYFVvHZFnGd999B1mWtZ4KeWEuYmIuYmIuYmIuYtJzLizsguBwOLBq1SpddseEM+YiJuYiJuYiJuYiJj3nwsKOiIiIKEywsCMiIiIKEyzsgiBJElq3bi3EtiJUgbmIibmIibmIibmISc+5sCuWiIiISGDsiq1jLpcLe/fuhcvl0noq5IW5iIm5iIm5iIm5iEnPubCwC4LT6cSGDRvgdDq1ngp5YS5iYi5iYi5iYi5i0nMuLOyIiIiIwgQLOyIiIqIwwcIuCJIkoVOnTrrsjglnzEVMzEVMzEVMzEVMes6FXbFEREREAmNXbB1zOp3YsmWLLm+iDGfMRUzMRUzMRUzMRUx6zoWFXRBcLhfy8vJ02fYczpiLmJiLmJiLmJiLmPScCws7IiIiojDBwo6IiIgoTLCwC4LBYECfPn1gMPCvSyTMRUzMRUzMRUzMRUx6zoVdsUREREQC01VX7A8//IBx48ahZcuWaNy4MXr37o3CwkKtp+XD4XBg/fr1cDgcWk+FvDAXMTEXMTEXMTEXMek5F00Lu/Pnz2PQoEEwm8349NNPcejQIWRmZuLaa6/Vclp+ZFlGUVERZFnWeirkhbmIibmIibmIibmISc+5mLT88IyMDERHRyMnJ0cda9++vXYTIiIiItIxTQu79evX45577sGYMWOQl5eHG264AdOmTcOTTz4Z8Pk2mw02m039+cKFC37jBoMBZrMZDofDp9I2Go0wmUyw2+3wvq3QZDLBaDT6jZvNZhgMBp/3ttlsMJvNkCQJdrvdZ24WiwWKovidto2IiIAsyz7jkiTBYrHA5XL5LH7oGXc6nT5r54TimLzp9Zi8jyNcjskzdz3n5OE9f70fUzjk5P17LFyOKRxy8p5XuBwTcOU5Ob94FZCMcA1O8jsm4/ZMQHHBdceskB+Th/ffsdb/7AVL08Lu6NGjyM7OxgsvvIAXX3wRu3fvRmJiIiIiIjBhwgS/56elpWHevHl+4wsXLkSjRo0AAH369MEDDzyATz/9FEVFRepz4uPjMWTIEKxevRrFxcXq+IgRI9C3b1+sWLECZ86cUcfHjh2Lzp07Y+HChepfflZWFqZOnYqoqCikp6f7zCElJQVlZWXIzs5WxywWC2bPno2jR49i1apV6njr1q0xbdo07N+/Hxs2bFDHO3XqhHHjxmH79u3Iy8tTx0N5TAB0fUy33HILjEYj/vSnP4XNMek9p169eqFx48bIysoKm2MKp5yysrLC7pgAfecUGxsLo9GI999/P2yO6UpzWrPtIB6VPsW2bduwVbpdPaadaSMxFDvxnuseHNmRHvJjuu+++9C2bVuf32Na/rN37NgxBEvTrliLxYL+/ftj586d6lhiYiIKCgqQn5/v9/xAZ+yio6Nx+vRptUukofxXHo+Jx8Rj4jHxmHhM4XZMC//9DZStryPJvBbOO5JhGJoCaeufIG2Zj0zHaEh3zsQzQzrq6pjqIqeff/4ZzZs3D6orVtPCLjY2FsOHD8eKFSvUsezsbLz22mv44Ycfanx9fS13YrfbsXr1ajz88MOwWCwh+xyqHeYiJuYiJuYiJubib/GmI3BsTkeSeS1gtAAuOzIdo2EeloLEhC71MgfRctHNcieDBg3Ct99+6zN2+PBhxMbGajSjwBRFQXFxMTSsgSkA5iIm5iIm5iIm5uIvMaELzMNSYFNMgMsOm2Kq16IO0HcumhZ2M2bMwK5duzB//nx89913eO+997Bs2TI888wzWk6LiIiINJRoWocIyQmbYkKE5ESiaZ3WU9INTQu7uLg4rFu3Dv/4xz/Qs2dPvPrqq1i0aBHGjh2r5bSIiIhIK3kLgNxUZDpG4xbnSmQ6RgO5qe5xqpGmXbEA8Jvf/Aa/+c1vtJ5GtUwmE0aMGOGzlANpj7mIibmIibmIiblU4lXUmYel4HBCFyze1BmZm4Gk3FT3c+JnhXwaes6Fe8USERGREL7820xsLz7vd0+dp6FicKfmGPD46xrOUBu6aZ7QC7vdjiVLlvi1JpO2mIuYmIuYmIuYmIuvndFPBWyU8DRU7Ix+ql7moedcan2O8fjx49i2bRuOHz+OS5cuoXXr1ujTpw+sVqu6SHC4URQFZ86c0WV3TDhjLmJiLmJiLmJiLr5mDO9a5WP13RWr11yCLuzee+89LF68GLt378Z1112HG264Addccw3OnTuH4uJiNGrUCGPHjkVycrJwy5UQERERNQRBFXZ9+/aFwWDAY489htWrVyMmJsbncZvNhvz8fLz//vvo378/lixZgjFjxoRkwkREREQUWFDNEx9//DHuv//+oN7w7NmzOHbsGOLi4q56cjWpr+YJWZZx9OhRdOzY0WdzYNIWcxETcxETcxETcxGTaLnUpt5hVywRERGRwOqlK/b06dM4cOAAvvrqK58/4chmsyEtLc1vI1/SFnMRE3MRE3MRE3MRk55zqXVXbGFhISZOnIhvvvlG7RaRJAmKokCSJLhcrjqfpAj02PLcEDAXMTEXMTEXMTEXMek1l1oXdpMmTULXrl3x1ltvoU2bNpAkKRTzIiIiIqJaqnVhd+zYMXz44Yfo3LlzKOZDREREDUFuGmAwBt4iLG8BILuAobPrf146V+t77BISErB///5QzEVYZrMZU6dOhdls1noq5IW5iIm5iIm5iKkh57Lz2HkgN9VdxHkr3y9257Hz2kwM+s6l1mfsVqxYgYkTJ+LAgQPo2bOn30E/8MADdTY5UUiShKioKF52FgxzERNzERNzEVNDzmVP7JPIL/4JSbmp7oH4WWpRl+kYDXPskxio0dz0nEutz9jt3LkT27dvx7x58zBmzBiMHDlS/TNq1KhQzFFzdrsd6enpur2RMlwxFzExFzExFzE15Fw8+79mOka7z9y92rqiqAuwX2x90nMutS7sEhMTMX78eJw8eRKyLPv8CdeOWCIiIqp7nuLOppgAlx02xaR5Uad3tS7sfvrpJ8yYMQNt2rQJxXyIiIioAUk0rUOE5IRNMSFCciLRtE7rKelarQu7hx56CLm5uaGYCxERETUkXvfU3eJcWXFZtnJDBQWt1luKpaamYtGiRbj//vtxyy23+DVPJCYm1ukEq1NfW4opigK73Q6LxaLLGynDFXMRE3MRE3MRU4POxbtRovzy6+JNR+DYnI4k81pg6JzAS6HUA9FyCelesR06dKj6zSQJR48erc3bXZX6KuxkWcbZs2fRqlUrITYDJjfmIibmIibmIqaGnMuXf5uJ7cXn/e6p8xR3gzs1x4DHX9dkbqLlEtK9Yo8dO1bln/os6uqTw+FAdnY2HA6H1lMhL8xFTMxFTMxFTA05l53RTwVslPA0VOyMfkqjmek7l1qvY0dERER0tWYM71rlY+yKvXK1LuwURcHatWuRm5uL06dPQ5Zln8c//PDDOpscEREREQWv1oXd9OnTsWzZMgwdOhRt2rQR4qbC+mCxWLSeAgXAXMTEXMTEXMTEXMSk11xq3TzRokULrFy5Evfdd1+o5hS0+mqeICIiItJKSJsnoqKi0LFjxyuenB7JsozvvvvO77IzaYu5iIm5iIm5iKmh5JL/1kzk5yQHfiwnGflvzaznGVVPz7nUurB75ZVXMG/ePPz666+hmI+QHA4HVq1apcvumHDGXMTEXMTEXMTUYHIxGGEtWepX3OXnJMNashQwGDWaWGB6zqXW99iNGTMG//jHP3Ddddehffv2fgsU7927t84mR0RERPpnnZSB/ByUF3een91FXX7sFFgnZWg9xbBR68LuscceQ2FhIcaNG9egmieIiIjoynkXd/a5K2CVnCzqQqDWhd3HH3+Mf//73xg8eHAo5iMkSZLQunVrFrGCYS5iYi5iYi5iami5WCdlwD53BSySE3bFJGxRp+dcat0V261bN6xevRq9evUK1ZyCxq5YIiIi/fBcfrUrJlh4xi5oIe2KzczMxKxZs3D8+PErnZ/uuFwu7N27Fy6XS+upkBfmIibmIibmIqaGlIv3PXWWeT+5i7oADRUi0HMutS7sxo0bh9zcXHTq1AmRkZFo0aKFz59w5HQ6sWHDBjidTq2nQl6Yi5iYi5iYi5gaSi6BGiWskzKELe70nEut77FbtGhRCKZBREREYUt2Bbzs6mmogKy/M2OiqnVhN3HixFDMg4iIiMKUdfLrVT/Ge+zqVFCXYv/3v//V6k1r+3zRSZKETp066bI7JpwxFzExFzExFzExFzHpOZegumKvv/56PPfcc3jsscfQrl27gM9RFAVffPEFFi5ciDvvvBOzZ8+u88lWxq5YIiIiCnd13hW7ZcsWFBUVoUOHDhgwYACeeeYZpKamIjMzEy+99BIeeughtGvXDpMnT8YDDzyAWbNm1cmBiMLpdGLLli26vIkynDEXMTEXMTEXMTEXMek5l6AKu5tuuglr1qxBcXExHnnkEfz4449Yu3Ytli9fji1btuCGG27A8uXLcfz4cUydOhVGo1h7vl0tl8uFvLw8XbY9hzPmIibmIibmIibmIiY951Kr5okbb7wRM2bMwIwZM0I1HyIiIiK6QrVex46IiIiIxMTCLggGgwF9+vSBwcC/LpEwFzExFzExFzExFzHpOZda7xUrEnbFEhERUbgL6V6xDZHD4cD69evhcDi0ngp5YS5iYi5iYi5iYi5i0nMuLOyCIMsyioqKIMuy1lMhL8xFTMxFTMxFTMxFTHrOpdaFXfv27fHHP/4RpaWloZgPEREREV2hWhd2SUlJ+H//7/+hY8eOGD58ON5//33YbLZQzI2IiIiIaqHWhd1zzz2HwsJCFBYWonv37khMTMT111+PZ599Fnv37g3FHDVnNBoRHx8fdgsv6x1zERNzERNzERNzEZOec7nqrliHw4ElS5YgOTkZDocDPXv2xPTp0zFp0qSQb57LrlgiIiLt5L81EzAYYZ2U4TcGAJBdsE5+veKxnGS/MapZvXTFOhwOrF69Gg888ACSkpLQv39/rFixAg8//DDmzJmDsWPHXulbC8dut2PlypWw2+1aT4W8MBcxMRcxMRcx6T4XgxHWkqXugq3SmLVkaUWBB3dRV3lMVHrOpVZbigHA3r17kZOTg3/84x8wGo0YP348srKy0K1bN/U5d999N+688846naiWFEVBcXExdLzkX1hiLmJiLmJiLmLSey7WSRnIz0F5cQefM3fePEVdfuyUKp8jEj3nUuvCLi4uDsOHD0d2djZGjhwJs9ns95zu3bvjkUceqZMJEhERkbi8izv73BWwSk7kx05xP1ZpTA9Fnd7VurA7evQoYmNjq31OkyZNkJOTc8WTIiIiIrEEup/Om1MxwCI5YVdM6nPsc1f4jVFo1foeuyNHjlT52JtvvnlVkxGVyWTCiBEjYDLVug6mEGIuYmIuYmIuYtJVLoHup0PFZVaTJMOumGCRnMjPSUZ+TrJa1HnG9EJXuVRS667YiIgIPPvss0hLS4PFYgEAnDlzBo8//jh27NiBc+fOhWSigbArloiIqP5UvldObYgAghrj5dgrE9Ku2K1bt2LDhg2Ii4vDwYMH8fHHH6Nnz5745ZdfsH///iuetMjsdjuWLFmiy+6YcMZcxMRcxMRcxKS3XKyTMtzFWclS2Oe29CvggnmdHs7c6S0Xb7Uu7AYMGICioiL06tUL/fr1w6hRo5CUlITNmzcjOjo6FHPUnKIoOHPmjC67Y8IZcxETcxETcxGTHnOxTspQL686Fcm/qJNdyI+d4m6gkF0+r6s8Jio95uJxRRePv/32WxQUFODGG2/Ejz/+iP/85z+4dOkSmjRpUtfzIyIiIoHk5yTD6nXvXGXVLT7My7ChV+szdunp6bBarRg+fDgOHDiAgoIC9Qxefn5+KOZIREREAvC+V84y7yddXV5tKGrdPHH99dfjb3/7G+699151zOFw4MUXX8TixYths9nqfJJVqa/mCVmWcfToUXTs2BEGwxVv1kF1jLmIibmIibmISU+5VNUAEY6NEaLlUpt6p9aF3dmzZ9GqVauAj+Xl5SE+Ph4A8P3336Ndu3Yh/QthVywREVH9qG4dO+4BG1oh7YqtqqgDoBZ1gHv3iePHj9f27YVks9mQlpZWr2cjqWbMRUzMRUzMRUx6ysU6+fUqz8hZJ2WEVVGnp1wqC9npND12klRHjy3PDQFzERNzERNzERNzEZNec9H+wjERERGJJTcNyFsQ+LG8Be7HSUgs7IiIiBqw/Ldm+nW17jx2HshNRWnWXe576zzyFgC5qe7HSUgs7IJgNpsxdepUmM1mradCXpiLmJiLmJiLmITIJcAesHtin8QOV3fElBXghgv73IPlRV2mYzT2xD6pzVzriRC5XKGQFXaSJIXqreudJEmIiooKq2MKB8xFTMxFTMxFTPWZS6Azc4C78eGApbdPcRdXugKDjIfU4g6vtlaLOvOwFCQmdAn5fLWk5+8LmyeCYLfbkZ6ertsbKcMVcxETcxETcxFTveYS4Mwc4F6qpKd9n1rcefaAzY+dgsIh78CmmACXHTbF1CCKOkDf35eQFXaHDh1CbGxsqN6eiIiIasGzV6t3cee9uHDPF/PUbcLsignWSRlINK1DhOSETTEhQnIi0bRO46OgmlzRXrEFBQVYs2YNSktL/arZDz/8EAAQHR199bMjIiKiOmOdlIH8HJSfmVsBq+RUd4yovAdsadZdiCkrQKZjNN7EaDyNtUjKTXW/UfwsbQ+EqlTrM3bvv/8+Bg0ahEOHDmHdunVwOBw4dOgQNm/ejKioqFDMkYiIiOqIdVKG35m5ynvAlkbFIaasADtc3WEeloLDqffCPCwFmY7RQG5q1UuhkOZqvaVYr1698PTTT+OZZ55BZGQk9u/fjw4dOuDpp5/G9ddfj3nz5oVqrn7qa0sxRVFgt9thsVh0eSNluGIuYmIuYmIuYtIiF08R5ynuDlh6o6d9n89er1/+bSacx3ZgkPGQz/jiTUfg2JyOwZ2aY8Dj4bPTRGWifV9CuqVYcXEx7r//fgBAREQE/ve//0GSJMyYMQPLli27shkLTlEUlJWVhVVDSDhgLmJiLmJiLmKq71wqn5nLj51S0TjhtV3YzuinUDjkHeTHTgFklzqemNAF5mEp2Bn9VL3MVyt6/r7UurBr0aIFLl68CAC44YYbcODAAQDAzz//jEuXLtXt7AThcDiQnZ0Nh8Oh9VTIC3MRE3MRE3MRU33m4l3UeYo4T0NFT/s+n27ZGcO7IjGhS8A9YBMTumDG8K4hn6+W9Px9qXVhd8cdd2Djxo0AgIcffhjTp0/Hk08+iUcffRQJCQlXPJG0tDRIkoTnn3/+it+DiIiIqiC7fIo6D09x531mjvSr1l2xf/nLX3D58mUAwOzZs2E2m7F9+3Y89NBDePnll69oEgUFBVi2bBl69ep1Ra8nIiKiCvlvzXSvW+dVxHnOvOXnJAOyy+dMXOVij/Trii7FtmvXzv1igwGzZs3C+vXrsXDhQjRv3rzWE/jll18wduxYLF++/IpeX18sFovWU6AAmIuYmIuYmIuYQpJLNYsRW0uWAgZj3X9mmNHr96XWXbEep0+fxunTpyHLss94bc+6TZw4ES1atEBWVhaGDBmC3r17Y9GiRUG9tr66YomIiESVtfEwjAbJb0cITxG3OnI8Hk76S8B77EgfalPv1PpSbGFhISZOnIhvvvnGr1tEkiS4XMFfo3///fexd+9eFBQUBPV8m80Gm82m/nzhwgW/cYPBALPZDIfD4VN0Go1GmEwm2O12n3mbTCYYjUa/cbPZDIPBAJvNBlmWcfz4cbRv3x4RERGQJMlvYWaLxQJFUfxutIyIiIAsyz7jkiTBYrHA5XLB6XT6jTudTp+/x1Ackzez2azLY5JlGSdOnEDnzp395qjXY/LMXc85SZKEb7/9Fu3bt4fBYAiLYwqHnFwul/p7zGKxhMUxhUNOsiyjtLQUXbp0gdPpvKJjur1kKXYeK8OflWQkJnRRjym/3WOQj27FwxffhX3uP2CVnNgR/RT6//6PsNlszKmaYzIajTh8+DBiY2PV32NaH1Owal3YTZo0CV27dsVbb72FNm3aXPH6LidOnMD06dPx+eefo1GjRkG9Ji0tLeA6eQsXLlTfo0+fPnjggQfw6aefoqioSH1OfHw8hgwZgtWrV6O4uFgdHzFiBPr27YsVK1bgzJkz6vjYsWPRuXNnLFy40Ocvf+rUqYiKikJ6errPHFJSUlBWVobs7Gx1zGKxYPbs2Th69ChWrVqljrdu3RrTpk3D/v37sWHDBnW8U6dOGDduHLZv3468vDx1nMdU9TF55hlOx6T3nHr06IHVq1f7zFHvxxSOOfGYxDkmz+euWbPmio7pTuUbJJl3IjMXyHLNxMVdq7HPcT0GK19ikPkQnIoBlvJtwb74vim+SE9nTjUc0z333IMPPvjA5zO1PKZjx44hWLW+FBsZGYmioiJ07ty5Ni/z89FHH2HUqFEwGiuu87tcLkiSpFa43o8Bgc/YRUdH4/Tp0+qpyVD814PNZkNWVhZmzJiBpk2bCvFfeVd7TN5E+S/X2h6TJ5eUlBRUptdj8sxdzzk5nU6kp6djxowZiIiICItjCoecLl++rP4ea9KkSVgcUzjk5P17TJKkKz4m4/ZMmLZlINMxGkvxW0zBP5FkXouSZv0Re2GPuhjxjuin0H/ca8yphmOSZdnv95iWx/Tzzz+jefPmobkUm5CQgP379191YZeQkICvv/7aZ2zSpEno1q0bkpOT/Yo6wH1wnr/gmsbNZnPAz63qZsiqxr3fNyIiQj0lG2gekiQFHDcYDAHHjUZjwOM0mUwwmfyjCcUx1TTOY+IxAbU7Js8vzkDfS70eU3Xjejkmz79wIiIi1PfU+zHVZjzsjynhRcBkQlJuKp5VPkKE5ERpVBxiywp89oIdVLIU+e8Z1HvshD6mGsZDmZOnGAv0e0yrYwpWrQu7FStWYOLEiThw4AB69uzpF+YDDzwQ1PtERkaiZ8+ePmNNmjRBy5Yt/ca1JkkSWrduLcS2IlSBuYiJuYiJuYipLnNZ7ByFp5UMREhOOBUDYryKOqB8vboclHfLcomT6uj5+1LrS7Hr16/H+PHj1d0nfN6sls0TlbErloiIqPY8e7gmmdcCRgvgsmOHqzsKh7wTsFu28jp2JLaQ7hWbmJiI8ePH4+TJk5Bl2efP1RR1ALBly5agi7r65HK5sHfv3qs+PqpbzEVMzEVMzEVMtc0l/62ZfmvTeRd1pc36AS+fAYbOwSDjITg2p2PxpiM+zw+0TRj50vP3pdaF3U8//YQZM2agTZs2oZiPkJxOJzZs2OBz0yVpj7mIibmIibmIqda5BFh4uH/JcveZOgA/NI9zD8bPAobOQZJ5LfqXLK/raYc9PX9fan2P3UMPPYTc3Fx06tQpFPMhIiJqcIzbFgDmCHdBVk7dFqxjS/c+rkNn+9wnd3D+TvR4cRuiy/a4n1954eHy9xrIPWAblFoXdl27dsXs2bOxfft23HLLLX7NE4mJiXU2OSIiooZg1/EyDP6+/Myap7grPzuHEmBnzNMYONT3NT3sX8E+tyWiJWfVu0l4FYrUMFxRV2zTpk2Rl5fns6Af4G6eCMfCTpIkdOrUSZfdMeGMuYiJuYiJuYjJk0vBdf3x5bHzSMpNdT8QP8t9pq7E/eMP538FAJ9twfodXwGL5IRdMbHDtY7p+ftyxXvFioBdsUREFC4CdbZmOkYjpkVjjLn4jrrIcH7sFADuy7HeYyzuwldIu2IbIqfTiS1btujyJspwxlzExFzExFzE5J1LYkIXmIelwKaYAJcdNsUE87AUjEl6Qy3g7Ir7QpvnrJ1l3k/uoq5SQwVdHT1/X2p9KfaFF14IOC5JEho1aoTOnTvjwQcfRIsWLa56cqJwuVzIy8uD1WoNuOI2aYO5iIm5iIm5iKlyLommdUD5vq4RkhOJpnXIz/kJ1vKiziI51aKOCw+Hjp6/L7WebVFRkbq2y0033QRFUXDkyBEYjUZ069YNS5YsQVJSErZv347u3buHYs5EREThJ28BkJuKTMdovInReBprkZSbCisqOl4Pzr8DPexf+b3UU9yBHbANXq0vxT744IO466678OOPP6KwsBB79+7FDz/8gOHDh+PRRx/FDz/8gDvvvBMzZswIxXyJiIjCjnF7plrUmYel4HDqvYhp0Vh93NqxJQCgx4vbqrz0yoWHCbiCM3Z/+tOfsHHjRp+b95o1a4ZXXnkFd999N6ZPn47/+7//w913312nE9WSwWBAnz59arUJL4UecxETcxETcxGTJ5eCY3nYWV7UebYAu/HaCKzBBJSeu4TBxacxIN79Gp6dCz09f19q3RXbtGlT/Otf/8KQIUN8xrds2YIRI0bg4sWLOHr0KHr37o0LFy7U5Vz9sCuWiIjCQdbGwzAaJL99XQF3t6xLVjBjeFcNZkYiCGlX7IMPPojHH38c69atw/fff48ffvgB69atw+TJkzFy5EgAwO7du9G1a/j8A+hwOLB+/Xo4HA6tp0JemIuYmIuYmIs4sjYeVvdv9eTy7JAOSEzogsWbjiBr42Gf5ycmdGFRV8/0/H2pdWH35ptvIiEhAY888ghiY2MRExODRx55BAkJCVi6dCkAoFu3blixYkWdT1YrsiyjqKgIsixrPRXywlzExFzExFzEMfDEMjg2p2PxpiM+uXjWsRt4YpnWU2zw9Px9qfU9dk2bNsXy5cuRlZWFo0ePQlEUdOrUCU2bNlWf07t377qcIxERkS6p+716LUEyoNN1GFC6HDu2HML6vb0BtMVftxyFsvV19+LEneZoNl/Svyu+K7Bp06bo1asXbr31Vp+ijoiIiMqV7/fq08EaPwulUXEYZDyEdhf24e+/9q0o6obO4f6udFWCOmP30EMP4e2330azZs3w0EMPVfvcDz/8sE4mJhKj0Yj4+HgYjUatp0JemIuYmIuYmIs2Ai0enJ+TDGtZgbu4KyvAN4bHECE5WdQJRM/fl6AKu6ioKHUj3KioqJBOSEQmk8mvC5i0x1zExFzExFy0413c2eeugLV8b9eCmCfw9NbbEVG+08SbzlFI1HqyBEDf35daL3cikvpa7sRut2P16tV4+OGHYbFYQvY5VDvMRUzMRUzMRXv2uS3V/V6X3rkLjs3pSDKvhQsmGOFUFycOtOQJ1S/Rvi8hXe7k119/xaVLl9SfS0pKsGjRInz++ee1n6lOKIqC4uJi6LgGDkvMRUzMRUzMRVv5OclqUWeRnOi3ZQKSzGvhvCMZr0mJcN6RjCTzWrVblrSl5+/LFa1j98477wAAfv75Z9x2223IzMzEgw8+iOzs7DqfIBERkZ7l5yS777GLnQLLvJ9wwHIrBhkPoTQqDq7BSQDg/t+hc5BkXov+Jcs1njHpWa0Lu7179+KOO+4AAKxduxZt27ZFSUkJ3nnnHSxevLjOJ0hERKQH+W/N9Nu/1VPUHbD0VrcA62m9F6VRcYgpK8CelS9VPDl+FjB0DgZ2aF6Ps6ZwU+vC7tKlS4iMjAQAfP7553jooYdgMBhw++23o6SkpM4nKAKTyYQRI0bAZKr1sn8UQsxFTMxFTMylHgRa2kR24YClN3ra9wGG8g7LobMRM+ML5MdOgUGRfXOJnwUMnV3vUydfev6+1Lp5olevXnjiiScwatQo9OzZE5999hmsVisKCwtx//3349SpU6Gaqx/uFUtERHUmN81dfFVaciT/rZm44cI+xPROUIsuz8LDAADZBevk193j5WfoDlp6oceL23wuw3ovUkxUGyFtnvi///s/zJw5E+3bt8eAAQNgtVoBuM/e9enT58pmLDi73Y4lS5bAbrdrPRXywlzExFzExFxqtvPYeSA3Fchb4DN+w4V9iCkrwIH8TysGy8/OWUuWVhR4XnrYv4J9bssaizrmIiY951Lrwm706NEoLS3Fnj178Nlnn6njCQkJyMrKqtPJiUJRFJw5c0aX3THhjLmIibmIibnUbE/sk8h0jPYt7vIWIKasADtc3dHTvt/vHjpv3mfnPN2vdsVU7Zk65iImPedyRReP27Zti7Zt2/qM3XbbbXUyISIiIi0kJnTBYqQgczOQlJsKbP0T4LKr68sZSlf4LTIM+C88DMBnaZP8nGRehqV6c8V7xRIREYWbxIQuMA9LgU0xAS47bIpJXTTYOinD70xc5TEAPkub5MdO8W+oIAoh7jwRBFmWcfToUXTs2BEGA2thUTAXMTEXMTGXWshbAOSmwqaYfPZw9VxqVc/EeZ+xKx8D4HdPXXUNFMxFTKLlEtLmiYbIYDCgc+fOQoRLFZiLmJiLmJhLkMqLukzHaNziXKnec1eadVfAM3HeYwctvQK+pXVShrsILF/HzhtzEZOec9HfjDVgs9mQlpYGm82m9VTIC3MRE3MRE3MJgldRZx6WgsOp98I8LAU7XN0RU1aA0qi4au+V6/HitiovvVonZahLonhjLmLScy76W3lPI3pseW4ImIuYmIuYmEv1viw+je3lRV1iQhcA7nvu1hb1wY4ywBTVGzGeJ8su9VKs95k466QM5Ocg4Nm5qjAXMek1FxZ2RETU4HgWGPY+A7cz+imYYyXEla5A/lsViw6PnrkEizcdgUtWMKD8uYHOvnmwA5a0xEuxRETU8ATY/mvG8K6IK1/SpPKiw4kJXTBjeNf6niVRrbErNgiyLOPs2bNo1aqVLm+kDFfMRUzMRUwNOZdAZ+cAMbb/asi5iEy0XNgVW8ckSUJUVBQkSdJ6KuSFuYiJuYipQecS4Oyct2C3/wqFBp2LwPScCwu7INjtdqSnp+v2RspwxVzExFzE1JBz8Sw34l3cXcn2X6HQkHMRmZ5zYWFHRERhI2vjYSzedMRv3DopA2siJ5Rv/1Vxdg7w3/6LSM9Y2BERUdgYeGIZHJvT/Yq7xZuOoPTcJTgVA7f/orDGwo6IiMLGgE7XIcm81qe4W7zpCByb05FkXguTJKtn5yrfUxfoki2R3rArNgiKosBut8NisejyRspwxVzExFzEFJa55Ka5lyWJn+U7Xr6DxE7XzXhMnounsRZJ5rUAKvZxPTj/DvSwfxWwWSI/JxmQXdWuVVdXwjKXMCBaLuyKrWOKoqCsrAw6roHDEnMRE3MRUzjmsvPYeSA31V3IBTDQ+A2+No3zK+qAK9v+KxTCMZdwoOdcWNgFweFwIDs7Gw6HQ+upkBfmIibmIqZwzGVP7JPIdIz2Le689nu1KSZESE44FcndOFHpzJzn0mtttv+qa+GYSzjQcy7cUoyIiHQpMaELFiMFmZuBpNxUYOufAJfdXewBiJCcgNECk8uO0nOXsHjTEXUPWA9u/0XhhmfsiIhItxITusA8LAU2xQS47O7/BdyXX4fOAV4+Awyd49dQQRSueMYuSBaLRespUADMRUzMRUzhmkuiaR0gOdVLr2pR52mqKP/fpNxU7CxpCSDwPXlaCddc9E6vubArloiIxBKg21Xd77VjS/c9cUNnux+o1AH7tmEeBhq/8S3sPPIW+L6WSCfYFVvHZFnGd999B1mWtZ4KeWEuYmIuYtJTLgG7Xcv3e0VuqvtxQC3qAOCHa+NwOPVe7Bnyrn9DhUf8LOGKOj3l0pDoORcWdkFwOBxYtWqVLrtjwhlzERNzEZOecgnU7Wrt2FJ9/IfzvwIADu7YAABYEzkBY5LeAFBxz12mYzS+LD5dzzOvPT3l0pDoORfeY0dEREKprts1pkVjjLn4Duxz30MPyelT1FV+/U5ZwQCNjoFIKyzsiIioXqj3yXktMeIZA+Cz20NiQhes2dcYzgsGmMq7Xc3DUjAmoQvsc99T93utXNR5VF7WhKih4KXYIEiShNatWwuxrQhVYC5iYi5iEiKX8vvkfHZ6KB+zliytKPDg3tZrzMV3YJJktds10bQO+TnJalFnkZy639NViFzIj55zYVcsERHVuUBn5wB3wWYtWYqDll7ubb3KfwYqtvzyHst0jMabGB1wv1fP8wLt90oUTtgVW8dcLhf27t0Ll0u7bWfIH3MRE3MRU73nEujsnJce9q9gn9tSLcw8+7Z6xgB3UWceloLDqfcipkVj9bWeRgrPlmDVfY7o+H0Rk55zYWEXBKfTiQ0bNsDpdGo9FfLCXMTEXMRU37kEKrq8z7B5LqXaFROskzJgnZShjjkVSS3qPPfK3XhtBNZETvDrdhVhv9erwe+LmPScC5sniIjoilV1ydXjoKVX+Zm4FbBKTncRBgS8T87qNRbTojHGeDVAeJoqFm864tftysuwRBV4xo6IiK5cFZdcPWfnLlw/0OfsHAD1rJ1l3k/qWb3KY2MuvhPw8mpiQhfMGN61Xg6NSI9Y2AVBkiR06tRJl90x4Yy5iIm5iKkucsl/a6ZfseV9yfXg/Dvcz/O65Ar4np0LptkhHO6dCxa/L2LScy7siiUiIj8B15wrL9gOWHrjYps49fKodxerenm1vKjzLuQOzr8DPexf+RR2Va1j53nfymNEDRG7YuuY0+nEli1bdHkTZThjLmJiLmKqdS4BLrFaJ2XggKU3etr3IfK/BQCqbogA4Hd2rseL2/zOxFknv642T1Qu4AKNhRt+X8Sk51xY2AXB5XIhLy9Pl23P4Yy5iIm5iKm2uVTV1drTvk8t7ryXKwF8L7k2O7kz4CVXvXex1jV+X8Sk51xY2BERUUDexZ13EdfzxbwaGyJ62L+q9n3D/UwckVZY2BERUZW815fzrDlXeVuvypdcG1LzA5FoWNgFwWAwoE+fPjAY+NclEuYiJuYipivNpXIRd2B+vM/ZuYOWXgFfx0uuweH3RUx6zoVdsUREDVzWxsMwGiR1lwcPT2PE6sjxeDjpLzgwP77iHrsX8/yexz1biUKDXbF1zOFwYP369XA4HFpPhbwwFzExFzF5ctm54gW/y6MDTyyDY3M61mQ+515+BBXF2g5Xd8Q2bwQAuNgmTm2cqNwty7NzV4bfFzHpORcWdkGQZRlFRUWQZVnrqZAX5iIm5iImTy6K5L+MyYBO1yHJvBZjLr6D73+2AQB++Okidri6Y5DxEAZ0ug6Ae2mSni/mBSzi2BBxZfh9EZOec2FhR0QUprI2HsbiTUd8xvqPe01tbFid+SwAIP/oT+rjpecuoeucT1Fy3oZBxkPA0DlA/Cyf92ARRyQuk9YTICKi0Bh4Yhm2F5/HYqTg6cEx6nhBzBOQj27FwxffhX3uP2At3ynC2rElknJT8azyESIkZ8CijojExjN2QTAajYiPj4fRaNR6KuSFuYiJuYjDc4nVsTkd2VuPIz4+Htlbj8OxOR2DjIfgVAw+y5gsdo6CTTEhQnLCppiw2DlK60MIe/y+iEnPubArlogonOUtAHJTkekYjTcxGk9jLZLMa1EaFYeYsgJ1GZM1kRNQeu4SksxrAaMFcNmR6RgN87AUv25ZIqpf7IqtY3a7HStXroTdbtd6KuSFuYiJudSD3DR3weYl/62Z7oaIvAXuxz3iZ6E0Kg5J5rX42jTOp6jzrEW3JnICxlx8x13UDZ0DvHwGGDpHPdtX+T49qjv8vohJz7mwsAuCoigoLi6Gjk9uhiXmIibmEno7j50HclN9izuDu9sVuanux8vl5yQjpqwATsWACMkJp2JQizrPmnM3NL+m4vmeRor4WWpx179keb0cV0PE74uY9JwLCzsiIoGpZ+K87Il9EpmO0UBuKkoXDgMAWDu2VB//4fyv7td6rUVnkmQ4YYRJkrHD1R0FMU+ozx/YoTkwdI7/Miblxd3ADs1DeIREVJfYFUtEJDKDZ905qGfYEhO6YM2+xsBFIOZCIfBqa/WeuJgWjTHm4juwz30PVsmprkXnvCMZqdsdmDPYjEHbMrBrczoWo/z+uaGzAQDW+ACfz65YIl3R9IxdWloa4uLiEBkZieuuuw4jR47Et99+q+WUAjKZTBgxYgRMJtbBImEuYmIudcuzq4P3osL5OckYc/EdrImcAJtiAlx22BQTzMNSMCbpDbUhwqkY1LXopCHJGDFiBKQhybzEKhB+X8Sk51w07Yr9//6//w+PPPII4uLi4HQ6MWfOHHz99dc4dOgQmjRpUuPr2RVLROGkqj1bAWBN5nPuM3HlRZtn3TnkpqpLlGDoHOQf/QnWkqXq80qj4hAz4wv/D8tb4L7sWn62jojEpZuu2M8++wyPPfYYevTogVtvvRU5OTkoLS1FYWGhltPyY7fbsWTJEl12x4Qz5iIm5lJJgA5WwH3vXGnWXT4drIH2bAWAxZuOoPTcJd9158qLukzHaNziXKnec2ctWap2u+bHTnE3SuQk++cSP4tFnQD4fRGTnnMR6hxjWVkZAKBFixYBH7fZbLDZbOrPFy5c8Bs3GAwwm81wOBw+e7wZjUaYTCbY7XafLheTyQSj0eg3bjabYTAY1Pc+c+YMLl++DJPJBEmS/MK2WCxQFMVvw+CIiAjIsuwzLkkSLBYLXC4XnE6n37jT6YTLVXEDcyiOyZvZbNblMXlyURQlbI7JM3c956Qoivp98Tym92O6mpwKin/C4O+XQ1EUKHf+QZ17u7IixFzYgwP5dnSPT4bD4UC/2BYYULocuAiswQS4XC78+YvDULa+7l6KBFDPxHmKOunOmTg4rDM+WvwJcNE9h7iYKNhsNsSNT0X+u4C1ZCm2/92JM2ea4fLlyzAajWH5z54ej8n791i4HBOg/5wC/R7T+piCJUxhpygKXnjhBQwePBg9e/YM+Jy0tDTMmzfPb3zhwoVo1KgRAKBPnz544IEH8Omnn6KoqEh9Tnx8PIYMGYLVq1ejuLhYHR8xYgT69u2LFStW4MyZM+r42LFj0blzZyxcuFD9y8/KysLUqVMRFRWF9PR0nzmkpKSgrKwM2dnZ6pjFYsHs2bNx9OhRrFq1Sh1v3bo1pk2bhv3792PDhg3qeKdOnTBu3Dhs374deXl56ngojwmAro/JI5yOSe859ejRA4D7+xIuxxRsTvHKTvS/bQDMCXPUY9rn6IovldFI2jIfjsObkH5yEO5UdmEo9rgbG+z7sTl7OradbYUuzgP4fflC96XnLuGmlz/DVOlDtahbFzESo2b/Hfv/aMWt8iFESjac3LUan9r64MZrI/D2pd/ip8sSbsjbi2+3p7uPaVIG1qWdgu1ECWC8BVlZWWH7z55ej8kjnI5J7zndc889AHx/j2l5TMeOHUOwhNl54plnnsHHH3+M7du348Ybbwz4nEBn7KKjo3H69Gn1mnOozthlZWVhxowZaNq0Kf+LSJBj8uSSkpKCyvR6TJ656zknp9OJ9PR0zJgxAxEREWFxTIFy2vvui4DRhL6//6M6VvDuHAz+fjlKo/rj+6a3ot8E92XWPStfwqATywAAitECqbyDVbpzJqw/vu1zT9yO6KcwoEMLmLamV9w7B2BH9FOIG58Ki8WCzH//B9Ff/wUP//IudkQ/hdsmzFeP6Y3N30FWFDw3tJPPMV2+fFn9PdakSZOw/GdPj8fk/XtMkqSwOCZA/znJsuz3e0zLY/r555/RvHnzoO6xE6Kwe+655/DRRx9h69at6NChQ9Cvq6/mCVmWcfToUXTs2BEGA5f+EwVzEVNDycWzRpz3Qr+LNx1Bvy0TMMh4qKJpwWtLr2dNH6n7sL555y61ScI+t6V675xl3k9YvOkInt56e/mCwhLWNRuPMUlvBJwDZBesk1+vcb4NJRe9YS5iEi2X2tQ7mhZ2iqLgueeew7p167BlyxZ06VK7/QjZFUtEWqpc3HkvCDzIeMhnz9WBnVvBWrLUp4MV8bPU13DPViKqim66Yp955hmsXLkS7733HiIjI3Hq1CmcOnUKv/76q5bT8mOz2ZCWluZ3OpW0xVzE1JBy8V5jzj63pVrkFQ55x2d9OU9RV7mDtTTrLp8u1lDu2dqQctET5iImPeeiaWGXnZ2NsrIyDBkyBNdff73654MPPtByWgHpseW5IWAuYmpIuVgnZahn2+yKCdZJGUg0rVMvuUZITrWoMw9LweHUe2EeloIdru6IKStAaVRcve3Z2pBy0RPmIia95qJpV6wAt/cREdWoxoWDPffHSU6UZt2FmLICZDpG402MxtuGeRho/MZ91q789YkJXbC2qA92lAGmqN6IKX+vgR2aA53ciwz77dkKYKD3GBFRAMIsd0JEJITcNMBg9NkjdeCJZdhefB75pa1gbX+turCvZzeIg5Ze6PHiNrWo2+Hq7j47l9AFjyy7FvklK5BUshTIa6m+7+iZS7B40xG4ZAUDPB/EPVuJ6CoJ0RV7peqzK/bs2bNo1aqVEN0x5MZcxKSnXPLfmgkYjOqlUADY+bdZGFj6Jkqj4vBDs97ujtPyzlYAWB05Hg8n/UUt6gCojRBf/m0mnMd2YJDxkF+3rGNzOgZ3ao4Bj9fcwRoKesqlIWEuYhItl9rUOzxjFwRJkhAVFQVJkrSeCnlhLmISNZdARRwMRlhLluLA/F242CYO1smvY0/sk1CObcOgsoKA73Pi3K/oOudTvG0oAIxQizoA2Bn9FIyxT8NQusLnUmpiQhcsRgp2ep+dq2ei5tLQMRcx6TkX7ctQHbDb7UhPT9ftjZThirmISYRc8t+a6V7jzZtaxMWr+7BaJ2XggKU3etr3IfK/7kIurnQFBhkPqc0NeLW1ug5dfuwUJJnX4mvTOAw0fuNT1AHAjOFdkZjQBdZJGX5ryyUmdMGM4V1De+DVECEX8sdcxKTnXFjYEVH4KS/ivIu7QEVcfk4yetr3qePVLVliHpaCgpgn1E5Xm2LCYucorY6QiCggFnZEFHa815fzFHfVFXE9X8yrccmSuNIVcGxOdy8ubLQgQnJe9dpyRER1jYUdEYWlqhYPDlTE5eckV2zpVb5kiefyq2dBYWvJ0pAsHExEVJfYFRsERVFgt9thsVh0eSNluGIuYhItl8r7sFbewstzBs/Txeq9ZEnhkHeQmNAFqzOfxcMX33W/ofd9deXdsjtjnsbAxxdod5BBEC0XcmMuYhItF91sKaYXiqKgrKyMCyoLhrmIqb5zCdgoUe7A/HifM3EH5sf7bOHlKeoOWHqr3bIno3qre73Gla4AADzc9wbkx05BpmM0viw+XfEB5btCDOzQPOTHebX4fRETcxGTnnNhYRcEh8OB7OxsOBwOradCXpiLmEKZS7DdroC7qPMUbVUVcRfbxFWcsSt/353RT6FwyDvIj51SsWTJ0NmwTsqAeVgKdkY/5fv58bPUhYVFxu+LmJiLmPScC9exIyL9ULtdoRZn1kkZODB/l7to+6/7ad5FXc8X8wCUF3H/hVrEeS9Jkp+TrBZxFUuSZKCyQFuKERGJhIUdEemGu9EBPsVdfk4yrJW6XXt67p0rL+oABCzivN+XiCgcsLALksVi0XoKFABzEVNVuQTa/cEzBgCQXbBOfj3gmLeDll7l3a4rYJWcauODd6OEd1HnrSEXcfy+iIm5iEmvubArlojqjacj1XsfVc8YAHU80Fjl1/c7vqLablfv1xER6Rm7YuuYLMv47rvvIMuy1lMhL8xFTNXlEmjh4GB5F3UAqu12vdLPCGf8voiJuYhJz7mwsAuCw+HAqlWrdNkdE86Yi5hqyqWqhYODHQNQ45IlV1NAhit+X8TEXMSk51xY2BFRSBS+M7vaosqpGHx2f7BOyvDbEaLyGAC/S7mBliwBKoq7yo0SREThjM0TRHTVAjVFKAYjBpYsxYH5u3CxTZxPV6q1ZCkgoeJ+uPKCzOp1eTXQWLOTO/3unWO3KxFRBZ6xC4IkSWjdurUQ24pQBeaijZoWCS58ZzZat26NuPGp6pm0yP8WuF9bqSnC+364QPfIVR7rYf+qynl5r0tH/vh9ERNzEZOec+EZuyBYLBZMmzZN62lQJcylbgW7FElFEVdxJs5nkeAzwLQXFwZcX84qOd3vewUdq4HWsKPg8fsiJuYiJj3nwjN2QXC5XNi7dy9cLt6rIxLmcuWC3pqrfMxaslQt8KyTMgKeietZuYgrP9vW88U89VKqU5H8izrZpTZKqJdSA42B981dDX5fxMRcxKTnXHjGLghOpxMbNmxAjx49YDQatZ4OlWMuVyHIrbkCqepMXKBFgtU16bzuk6ss0OXT6i6p8kzdleH3RUzMRUx6zoVn7IjCXKCzc97LgRycf4f7edWcdQu07Ij3mTjvIs4iOWHj+nJERJpgYUcU7tSzc4GLqR72r2os2AItReIp4iovErwj+imkGxJxwHIr15cjIqpnLOyCIEkSOnXqpMvumHDGXPzV5uycp5CrqWDLz0musogLtEhw3PhUdOrUCRda9+f6cgLh90VMzEVMes6Fe8US6VCgDlagomA7aOmFHi9u8xsH4LOXKgCf/VXVQqyaPVsPzI+vuGT7Yp46n8j/Fvi81vuz1Y5aIiKqNe4VW8ecTie2bNkCp9P/xm/Sju5zyU0D8hb4DGVtPIzFm464x3PTAFSchVu86QiyNh52PzFQB6uXHvav1LNkVZ2dA2remiuQQDs9WCe/jp4v5iE/dgoUl28uXF9ODLr/voQp5iImPefCwi4ILpcLeXl5umx7Dmd6z2XnsfNAbqpPcTfwxDL02zIByE11Pw6oRVy/LRMw8MQyAFUvOVLTHqvel1OD2porwLIj3kVcoJ0e+o2fr+tcwpXevy/hirmISc+5cLkTovqQm+ZeBy5+ljq0J/ZJ5Bf/hKTcVODYVuCxf2GA8VvAeAg7XN3xV9dDGAigIOYJyEe3YpDxEErLmgCoeckRALDPXVHlHqsH59/ht4tDoK25uOwIEZG+sLAjqgc7j53HwNI33T+UF3eJCV2QX9oKKAFwfBvwamvAZccOV3cMMh7CruPL0XXOeTyNtRhkPoTSqDjElBXUuG4cAL+14yqfnevx4raKM3yVdnFgwUZEpF+8FBsEg8GAPn36wGDgX5dIRM0lUGfqntgnkekYDeSmonThMPdg3gJYS5Yi0zEaNsUEuOywKSYUDnkHGDoHSea1+No0DknmtcDQOYiZ8UXQHaze984dtPQKOM9QdaeKmktDx1zExFzEpOdc2BVLVMe8Cyvvs19rMp/DmIvvuH8wWgCXHZmO0RjYuRWsJUthU0yIkJzA0DlY7ByFp7fejojyxX7fvHMX4kpX1LqDtaY5ERGR+NgVW8ccDgfWr18Ph8Oh9VTIS33nEuhMnGcsPydZ7U6tat24MRffwZrICT5n5zxFXaZjNG5xrlTP6vXbMsFd5BktiJCc6LdlQo0drNZJGfV+di4Qfl/ExFzExFzEpOdcWNgFQZZlFBUVQZZlradCXuo9l0A7OJSPWUuWupsjKqm8q8OY/tHqWbiI8nvfMh2jYR6WgsOp96Kw/ZPqPXbocCfw8hmURsVhUHlDRUHMEwCq6GBF+b1zVRRw9bXsCL8vYmIuYmIuYtJzLmyeoAYva+NhGA0SEhO6qGOeBYALYp6AS1YwY3jX8sudKD8Tt9NnAWBv3pc9+x2v6Ey1dmwJ5KYi0zEab2I03jbMw0DjN+6zduWf/azxQwwsL+JMrpswAMAPzXoDAAaVFUAqWQ5gQcAOVg9eaiUiarhY2FGDN/DEMmwvPo/FSKko7srPxMlHt8LUYRAA3zNd6pm4yjs4zF3hM+bd2OAp6szDUnA4oQseWXYt8ktWIKlkKZDXEoifhYEdmgOd5qDQOQouWcEAeC05krcAA1nEERFRNXgpNghGoxHx8fEwGv0vtZF26iqXAZ2uQ5J5LRyb0927PsC9dpznkuj1ZfsAVL+/qnVSRrW7OnjufYtp0VgtHt9/ygrzsBRkOkbjy+LT7skMnQ3Ez0JiQhfMGN7Vd6Lxs9yPC47fFzExFzExFzHpORd2xVKDUdX+qgBQmnUXYsoK1MukT2MtksxrK9aOq2Z/1UBjgG9natbGw7jxqzcw5uI7fp2pizcdUS/3EhERVcau2Dpmt9uxcuVK2O12radCXqrLJVAHa1X7q+bnJCOmrAClUXE1rh0H+J6J83S/1rRu3IzhXTEm6Y2AjQ0Bz87pGL8vYmIuYmIuYtJzLrzHLgiKoqC4uBg6PrkZNrzPunly2fP3FEgms/sJsst9T5paxO3CxTZxsE5+3b2/6vxd7mVC/lv+fl6XVwtinvBdO845CnE17OAQSEPf1YHfFzExFzExFzHpORcWdiSuAPuregq20qxCtLslHgCgGIwY6LUwL4Cqi7gq9lctiHkCjs3piDCXrx3nsrvXjjMeqnZ/Vcgu9TO9z8R5OmjrY904IiIiDxZ2JIRA97959lct3fs5fmjWWz3rVppViJiyAny92wbgrsDvV00RV3l/VU9R57n8ivhZKM26C4PKCrDD1R2FMU/AisBn4qpbF64hnJ0jIiKxsLALgslkwogRI2Ay8a+rOoGKM88YAPUyaaCxQJdO98Q+CeXYNgwqK6j4kLwFiCkvuAbZv8JNyiFYTlS95EjlIk7desvr8uqwLyejp3m/WtQBgdeOA3gmLhj8voiJuYiJuYhJz7nob8YaMBqN6Nu3r9bTEJ+6M4PX2aryMaDiMmmgsUCXTuNKV8BavljvoLIC4NXW6v6q5mEpiNt6u0/BBgD2uSuqLeIOzI+HNcD+qqVRcYjxuuTLteOuHL8vYmIuYmIuYtJzLuyKDYLdbseSJUt02R1Tn7z3SPXrSK1Bfk6yuvepeum0vFGhcMg7PvurmoelIK7UXcDZPEuOlO/XaqlcxAWxv2p+7BTElBUEnrNO1o4TCb8vYmIuYmIuYtJzLjxjFwRFUXDmzBlddsfUhWAvsQIVZ94C7cIQzFigS6fWvAWA1/6qI7+a6r4cG/0Uvvi+Ke668RcM8joD6J5DvF8Rd7FNHA78F+r+qj7FHS+v1pmG/n0RFXMRE3MRk55zYWHXQNWmWPNcOvXZHzXQJVZUNC04FUONl0kDjVW+dFp54eAcwx8xqHzNuf7jXsMX6ekBjy9QEcf9VYmIKNyxsGuogr0fzksP+1c+Z7oq89yvpl5O9bpMCsCnYAs0Vvn+N09Rt8PVXd1fde3rG7CjzN3U4NyeCQCQAiw5wiKOiIgaIm4pFgRZlnH06FF07NgRBoMOb0sMtB4cKgqxE1H9ED1js/ozAL/mgmC30vIUdZVfH+g9vce8L532fDEPAPDl32bCeWwHBnmtJQe4t+BybE7HoI7N0Sp+in5zCVO6/76EKeYiJuYiJtFyqU29wzN2QTAYDOjcubPW07hinvXgAPgUd9aOLYESILqs0GedNyDwvW9A9ZdTnYrBp6irjUCXTndGPwVj7NMwlK7wOeuWmNAFi5GCfFnBDB3nEq70/n0JV8xFTMxFTHrORfsyVAdsNhvS0tJgs9m0nkqNAu2Ruif2SWQ6RgO5qShdOMw9mLcAyE1FpmO02lmqNitMyvDZH9VTpFXuOq3ciWqSZJ9mBQDqzgw+e6QGGLNOfh09X8zzGZsxvCsSE7oEXAg4MaELpt0Zq5tcGhI9fV8aEuYiJuYiJj3nwjN2QdJNy3OAe+cSE7pgzb7GwEUg5kKhz3pwMS0aI+Ji9fe+qWNe+6RWe9nWu+M0wM4Mdblbg25yaWCYi5iYi5iYi5j0mgvP2IWZQGvJ5eckY8zFd7AmcoLPenAxLRpjzMV31HXePK/zXvut8lh1hdfVrGNHREREV49n7MKQZ122yvfJjenYEsitWA/OU9TVVKwdnL8TPexf+T4QoBPV+7O5JhwREVH9Y1dsEGRZxtmzZ9GqVSshumM8Aq1Fpz6Wk4y448tgkmT3JdVhyeo9dW9iNN42zMNA4zc++6NWuY4dKpYNqe4yan0TNZeGjrmIibmIibmISbRcalPvsLALgqIosNvtsFgskCSpTt872IWCA455rRt3sU2cz9ptnvvfPPfJAVD3WE1M6KIuGZJkXutT3OlJKHOhK8dcxMRcxMRcxCRaLrWpd7QvQ3XAbrcjPT39qm+kDNSx6ml2ODA/3l28eY1ZS5ZWFHMBxqyTMtR14yL/W+D+jEpNDZZ5P+GgpRcAIKZFYyQmdAHgbqgwD0tBpmM0viw+fVXHpZW6yoXqFnMRE3MRE3MRk55zYWFXn9SO1YriLlBxFqz8nOSKRX3t+9xr0VXqVAWAz+PewprICe576rw+21Pc7Yx+qg4OjoiIiLTG5ol65N3U4FmOxLO3qk9xVs1CwYHGrJMyYJ/bsnyRYAkF7Z/2ubQ7Y3hXYPgbyM9p7NfU4DmDR0RERPrHwq6eVdWx6l2cBdrVobqx/Jxkn3XnqvtsIiIiCl9snghCKG6i9C7iLPN+Uu+Nq24f1trszXol23rpjWg3t5IbcxETcxETcxGTaLmweaKOKYqCsrIyBKqBAzZElI/7NER4OTA/3mdrrgPz46tdFLiqMU9R572NV0NaJLi6XEg7zEVMzEVMzEVMes6FhV0QHA4HsrOzIW9Ode+x6q28IaI06y4gN00djvxvQcCGiAPz49VirKriLFgX28RVnLGr1JDhszdrmPLk4nA4tJ4KeWEuYmIuYmIuYtJzLrzHrhZ2HS/D4O+Xu38oX/fNOikDpVmFiCkrwIF8O3oOne3XEOHZO9W7qOv5Yh6A8uLsv/B5XsBdHQKMea9bV7mIC/fLsEREROSPhV0t7I6ejC+PnUdSbqp7IH4WkLcAMWUF2OHqjkH2/T5drd73vNnnrkBPzz1x5UUdELg4C7S7Q3U7PrCIIyIiIoCXYoNmsVjwzJCO6qK+yE0FXm2tbtNVOOQd9Z457w5W66QMn3Hvos6bdVKGUNt16YXFYtF6ChQAcxETcxETcxGTXnNhV2wVqtuHdU3mcxh1YSVMkgybYsKbd+5CXOkKvw5WnzN2lcaJiIiIgsGu2LrgtUuELMv47rvvIMsy8nOSMebiO2pRFyE5MfKrqQE7WKvqdg33btX64p0LiYO5iIm5iIm5iEnPubCwq0LlZUNWrVrlsw9rpmM0bnGuxA5Xd8SUFaA0Ks7n8mtDX4qkPjgcDqxatUqXXUvhjLmIibmIibmISc+5sHmiGp5dIgaVLEV/xYSIE+5dHTIdo2EeloLDCV2w9vUN2FEGDCorcC+FUt4t6+l2vdgmLuB7hvtSJERERFT/WNjVwL3V1wpElO/D+mfnb2EelqLusTp65hIs3nQEuzanY3DxaQyIL38du1iJiIionrGwq4FnH1bP/XQxLRpjTHlR55GY0AWLkYKdsoIBGs2zIZIkCa1btxZiuxeqwFzExFzExFzEpOdc2BVbjcr7rjakfViJiIhIDLrril2yZAk6dOiARo0aoV+/fti2bZvWU/Ip4m6bMB979+7FbRPms/lBIC6XC3v37oXLxfsVRcJcxMRcxMRcxKTnXDQv7D744AM8//zzmDNnDoqKinDHHXfg3nvvRWlpqbYTK9/CyzopA06nExs2bIDT6Www+7DqgXcuJA7mIibmIibmIiY956L5PXYLFy7E5MmT8cQTTwAAFi1ahH//+9/Izs5GWlqaZvNi8wMRERHpjaZn7Ox2OwoLC3H33Xf7jN99993YuXOnRrMiIiIi0idNz9idPXsWLpcLbdq08Rlv06YNTp065fd8m80Gm82m/nzhwgW/cYPBALPZDIfD4bNitNFohMlkgt1uh3e/iMlkgtFo9Bs3m80wGAyw2Wyw2+3o0KED7HY7zGYzJEmC3W73mZvFYoGiKH6LGUZERECWZZ9xSZJgsVjgcrl8TvN6xp1Op891/VAckze9HpPdbkfHjh0hSVLYHJNn7nrOSZIk9fsSLscUDjl5/x4Ll2MKh5y8f4+FyzEB+s8p0O8xrY8pWJpfigXg106sKErAFuO0tDTMmzfPb3zhwoVo1KgRAKBPnz544IEH8Omnn6KoqEh9Tnx8PIYMGYLVq1ejuLhYHR8xYgT69u2LFStW4MyZM+r42LFj0blzZyxcuFD9y1+4cCGmTp2KqKgopKen+8whJSUFZWVlyM7OVscsFgtmz56No0ePYtWqVep469atMW3aNOzfvx8bNmxQxzt16oRx48Zh+/btyMvLU8dDeUwAdH9MFosFaWlpYXVMes/pl19+wcKFC8PqmMIlp4ULF4bdMQH6z8lisWDlypVhdUx6z+naa6/1+T2m5TEdO3YMwdJ0uRO73Y7GjRtjzZo1GDVqlDo+ffp07Nu3z+cvGgh8xi46OhqnT59W239D8V8PTqcT+fn5sFqtuOaaa/hfRIIck9PpxO7du3HHHXf4dS7p9Zg8c9dzToqiIC8vD7fffjtMJlNYHFM45ORwONTfY40aNQqLYwqHnJxOJ7788kvceeedkGU5LI4J0H9OkiT5/R7T8ph+/vlnNG/ePKjlTjQ9Y2exWNCvXz9s3LjRp7DbuHEjHnzwQb/nR0REICIiIqhxs9lc5WfWZtzzvjt27MAdd9wBg8HgM+5NkqSA4waDIeC40WiE0Wj0GzeZTOo/SN7q+piCGRf9mLZu3YqBAweG1TF56PWYbDYbtm/fjsGDB/t9tl6PqbpxvRyToijq7zHPe+r9mGozLvIxbdu2DYMGDapyjno8Jg+95lTd7zGtjilYml+KfeGFFzB+/Hj0798fVqsVy5YtQ2lpKaZMmaL11IiIiIh0RfPC7ne/+x1++ukn/PGPf8TJkyfRs2dPfPLJJ4iNjdV6akRERES6onlhBwDTpk3DtGnTtJ5GlQwGA/r06VOrU6EUesxFTMxFTMxFTMxFTHrOhXvFEhEREQlMd3vFis7hcGD9+vV+nSqkLeYiJuYiJuYiJuYiJj3nwsIuCLIso6ioqFYLBFLoMRcxMRcxMRcxMRcx6TkXFnZEREREYUKI5okr5bk90LO1WKjYbDZcvnwZFy5cqHI9Gqp/zEVMzEVMzEVMzEVMouXiqXOCaYvQdfPE999/j+joaK2nQURERBRyJ06cwI033ljtc3Rd2MmyjB9//BGRkZEB95atK56ty06cOMHuW4EwFzExFzExFzExFzGJlouiKLh48SLatWtX4xIsur4UazAYaqxc61KzZs2ECJh8MRcxMRcxMRcxMRcxiZRLVFRUUM9j8wQRERFRmGBhR0RERBQmWNgFISIiAnPnzhWiM4YqMBcxMRcxMRcxMRcx6TkXXTdPEBEREVEFnrEjIiIiChMs7IiIiIjCBAs7IiIiojDBwi4IS5YsQYcOHdCoUSP069cP27Zt03pKDUZaWhri4uIQGRmJ6667DiNHjsS3337r8xxFUfDKK6+gXbt2uOaaazBkyBAcPHhQoxk3TGlpaZAkCc8//7w6xly08cMPP2DcuHFo2bIlGjdujN69e6OwsFB9nLnUP6fTiZdeegkdOnTANddcg44dO+KPf/yjzwbzzCX0tm7dihEjRqBdu3aQJAkfffSRz+PBZGCz2fDcc8+hVatWaNKkCR544AF8//339XgUQVCoWu+//75iNpuV5cuXK4cOHVKmT5+uNGnSRCkpKdF6ag3CPffco+Tk5CgHDhxQ9u3bp9x///1KTEyM8ssvv6jPSU9PVyIjI5V//vOfytdff6387ne/U66//nrlwoULGs684di9e7fSvn17pVevXsr06dPVceZS/86dO6fExsYqjz32mPLll18qx44dU7744gvlu+++U5/DXOrfa6+9prRs2VL517/+pRw7dkxZs2aN0rRpU2XRokXqc5hL6H3yySfKnDlzlH/+858KAGXdunU+jweTwZQpU5QbbrhB2bhxo7J3715l6NChyq233qo4nc56PpqqsbCrwW233aZMmTLFZ6xbt25KSkqKRjNq2E6fPq0AUPLy8hRFURRZlpW2bdsq6enp6nMuX76sREVFKUuXLtVqmg3GxYsXlS5duigbN25U4uPj1cKOuWgjOTlZGTx4cJWPMxdt3H///crjjz/uM/bQQw8p48aNUxSFuWihcmEXTAY///yzYjablffff199zg8//KAYDAbls88+q7e514SXYqtht9tRWFiIu+++22f87rvvxs6dOzWaVcNWVlYGAGjRogUA4NixYzh16pRPRhEREYiPj2dG9eCZZ57B/fffj7vuustnnLloY/369ejfvz/GjBmD6667Dn369MHy5cvVx5mLNgYPHoxNmzbh8OHDAID9+/dj+/btuO+++wAwFxEEk0FhYSEcDofPc9q1a4eePXsKlZOu94oNtbNnz8LlcqFNmzY+423atMGpU6c0mlXDpSgKXnjhBQwePBg9e/YEADWHQBmVlJTU+xwbkvfffx979+5FQUGB32PMRRtHjx5FdnY2XnjhBbz44ovYvXs3EhMTERERgQkTJjAXjSQnJ6OsrAzdunWD0WiEy+VCamoqHn30UQD8voggmAxOnToFi8WC5s2b+z1HpJqAhV0QJEny+VlRFL8xCr1nn30WX331FbZv3+73GDOqXydOnMD06dPx+eefo1GjRlU+j7nUL1mW0b9/f8yfPx8A0KdPHxw8eBDZ2dmYMGGC+jzmUr8++OADrFy5Eu+99x569OiBffv24fnnn0e7du0wceJE9XnMRXtXkoFoOfFSbDVatWoFo9HoV4mfPn3ar6qn0Hruueewfv165Obm4sYbb1TH27ZtCwDMqJ4VFhbi9OnT6NevH0wmE0wmE/Ly8rB48WKYTCb175651K/rr78e3bt39xm7+eabUVpaCoDfF6384Q9/QEpKCh555BHccsstGD9+PGbMmIG0tDQAzEUEwWTQtm1b2O12nD9/vsrniICFXTUsFgv69euHjRs3+oxv3LgRAwcO1GhWDYuiKHj22Wfx4YcfYvPmzejQoYPP4x06dEDbtm19MrLb7cjLy2NGIZSQkICvv/4a+/btU//0798fY8eOxb59+9CxY0fmooFBgwb5LQd0+PBhxMbGAuD3RSuXLl2CweD7r1uj0agud8JctBdMBv369YPZbPZ5zsmTJ3HgwAGxctKsbUMnPMudvPXWW8qhQ4eU559/XmnSpIly/PhxrafWIEydOlWJiopStmzZopw8eVL9c+nSJfU56enpSlRUlPLhhx8qX3/9tfLoo49ymQANeHfFKgpz0cLu3bsVk8mkpKamKkeOHFFWrVqlNG7cWFm5cqX6HOZS/yZOnKjccMMN6nInH374odKqVStl1qxZ6nOYS+hdvHhRKSoqUoqKihQAysKFC5WioiJ1+bJgMpgyZYpy4403Kl988YWyd+9eZdiwYVzuRI/++te/KrGxsYrFYlH69u2rLrVBoQcg4J+cnBz1ObIsK3PnzlXatm2rREREKHfeeafy9ddfazfpBqpyYcdctLFhwwalZ8+eSkREhNKtWzdl2bJlPo8zl/p34cIFZfr06UpMTIzSqFEjpWPHjsqcOXMUm82mPoe5hF5ubm7Af59MnDhRUZTgMvj111+VZ599VmnRooVyzTXXKL/5zW+U0tJSDY6mapKiKIo25wqJiIiIqC7xHjsiIiKiMMHCjoiIiChMsLAjIiIiChMs7IiIiIjCBAs7IiIiojDBwo6IiIgoTLCwIyIiIgoTLOyIiIiIwgQLOyJqMIYMGYLnn3/+il9//PhxSJKEffv21dmciIjqkknrCRAR1ZcPP/wQZrNZ62kQEYUMCzsiajBatGih9RSIiEKKl2KJqMHwvhTbvn17zJ8/H48//jgiIyMRExODZcuW+Tx/9+7d6NOnDxo1aoT+/fujqKjI7z0PHTqE++67D02bNkWbNm0wfvx4nD17FgCwZcsWWCwWbNu2TX1+ZmYmWrVqhZMnT4buQImowWJhR0QNVmZmplqwTZs2DVOnTsV//vMfAMD//vc//OY3v8FNN92EwsJCvPLKK5g5c6bP60+ePIn4+Hj07t0be/bswWeffYb//ve/ePjhhwFUFJLjx49HWVkZ9u/fjzlz5mD58uW4/vrr6/14iSj88VIsETVY9913H6ZNmwYASE5ORlZWFrZs2YJu3bph1apVcLlc+Nvf/obGjRujR48e+P777zF16lT19dnZ2ejbty/mz5+vjv3tb39DdHQ0Dh8+jK5du+K1117DF198gaeeegoHDx7E+PHjMWrUqHo/ViJqGFjYEVGD1atXL/X/S5KEtm3b4vTp0wCAb775BrfeeisaN26sPsdqtfq8vrCwELm5uWjatKnfexcXF6Nr166wWCxYuXIlevXqhdjYWCxatCg0B0NEBBZ2RNSAVe6QlSQJsiwDABRFqfH1sixjxIgRyMjI8HvM+1Lrzp07AQDnzp3DuXPn0KRJk6uZNhFRlXiPHRFRAN27d8f+/fvx66+/qmO7du3yeU7fvn1x8OBBtG/fHp07d/b54yneiouLMWPGDCxfvhy33347JkyYoBaPRER1jYUdEVEAv//972EwGDB58mQcOnQIn3zyCV5//XWf5zzzzDM4d+4cHn30UezevRtHjx7F559/jscffxwulwsulwvjx4/H3XffjUmTJiEnJwcHDhxAZmamRkdFROGOhR0RUQBNmzbFhg0bcOjQIfTp0wdz5szxu+Tarl077NixAy6XC/fccw969uyJ6dOnIyoqCgaDAampqTh+/Li6jErbtm2xYsUKvPTSS9y9gohCQlKCuZGEiIiIiITHM3ZEREREYYKFHREREVGYYGFHREREFCZY2BERERGFCRZ2RERERGGChR0RERFRmGBhR0RERBQmWNgRERERhQkWdkRERERhgoUdERERUZhgYUdEREQUJljYEREREYWJ/x+V8sYrmEuGPQAAAABJRU5ErkJggg==",
+      "text/plain": [
+       "<Figure size 640x480 with 1 Axes>"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "# calibrated predictions\n",
+    "with torch.no_grad():\n",
+    "    cal_pred = cal_model(x)\n",
+    "fig, ax = plt.subplots()\n",
+    "idx_sort = torch.argsort(pred)\n",
+    "ax.plot(pred[idx_sort].cpu(), \"C0x\", label=\"original\")\n",
+    "ax.plot(cal_pred[idx_sort].cpu(), \"C1x\", label=\"calibrated\")\n",
+    "ax.grid(color=\"gray\", linestyle=\"dashed\")\n",
+    "ax.set_xlabel(\"index\")\n",
+    "ax.set_ylabel(f\"{vocs.objective_names[0]} (mm)\")\n",
+    "ax.legend(loc=\"upper left\")\n",
+    "fig.tight_layout()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 20,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# calibration parameters\n",
+    "df_x = pd.DataFrame(\n",
+    "    columns=[[\"x_offset\"] * 2 + [\"x_scale\"] * 2, [\"target\", \"learned\"] * 2]\n",
+    ")\n",
+    "df_y = pd.DataFrame(\n",
+    "    columns=[[\"y_offset\"] * 2 + [\"y_scale\"] * 2, [\"target\", \"learned\"] * 2]\n",
+    ")\n",
+    "for df in [df_x, df_y]:\n",
+    "    for col in df.columns:\n",
+    "        model = miscalibrated_objective_model\n",
+    "        if col[-1] == \"learned\":\n",
+    "            model = cal_model\n",
+    "        values = getattr(model, col[0])\n",
+    "        if col[-1] == \"learned\":\n",
+    "            if \"offset\" in col[0]:\n",
+    "                values = -values\n",
+    "            elif \"scale\" in col[0]:\n",
+    "                values = 1.0 / values\n",
+    "        if values.shape[0] == 1:\n",
+    "            df[col] = values.detach().cpu().tolist()\n",
+    "        else:\n",
+    "            df.loc[:, col] = values.detach().cpu().tolist()\n",
+    "pd.set_option(\"display.float_format\", \"{:.4f}\".format)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 21,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/html": [
+       "<div>\n",
+       "<style scoped>\n",
+       "    .dataframe tbody tr th:only-of-type {\n",
+       "        vertical-align: middle;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe tbody tr th {\n",
+       "        vertical-align: top;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe thead tr th {\n",
+       "        text-align: left;\n",
+       "    }\n",
+       "</style>\n",
+       "<table border=\"1\" class=\"dataframe\">\n",
+       "  <thead>\n",
+       "    <tr>\n",
+       "      <th></th>\n",
+       "      <th colspan=\"2\" halign=\"left\">x_offset</th>\n",
+       "      <th colspan=\"2\" halign=\"left\">x_scale</th>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th></th>\n",
+       "      <th>target</th>\n",
+       "      <th>learned</th>\n",
+       "      <th>target</th>\n",
+       "      <th>learned</th>\n",
+       "    </tr>\n",
+       "  </thead>\n",
+       "  <tbody>\n",
+       "    <tr>\n",
+       "      <th>0</th>\n",
+       "      <td>0.1489</td>\n",
+       "      <td>0.1564</td>\n",
+       "      <td>1.0507</td>\n",
+       "      <td>1.0506</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>1</th>\n",
+       "      <td>0.2305</td>\n",
+       "      <td>0.1901</td>\n",
+       "      <td>1.0882</td>\n",
+       "      <td>1.0870</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>2</th>\n",
+       "      <td>0.0265</td>\n",
+       "      <td>0.0551</td>\n",
+       "      <td>1.1556</td>\n",
+       "      <td>1.1558</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>3</th>\n",
+       "      <td>0.0396</td>\n",
+       "      <td>0.0473</td>\n",
+       "      <td>1.2093</td>\n",
+       "      <td>1.2091</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>4</th>\n",
+       "      <td>0.0922</td>\n",
+       "      <td>0.1140</td>\n",
+       "      <td>1.2400</td>\n",
+       "      <td>1.2399</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>5</th>\n",
+       "      <td>0.1902</td>\n",
+       "      <td>0.1990</td>\n",
+       "      <td>1.0483</td>\n",
+       "      <td>1.0483</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>6</th>\n",
+       "      <td>0.1470</td>\n",
+       "      <td>0.1598</td>\n",
+       "      <td>1.0847</td>\n",
+       "      <td>1.0847</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>7</th>\n",
+       "      <td>0.2689</td>\n",
+       "      <td>0.3230</td>\n",
+       "      <td>1.2045</td>\n",
+       "      <td>1.2045</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>8</th>\n",
+       "      <td>0.1367</td>\n",
+       "      <td>0.1748</td>\n",
+       "      <td>1.2746</td>\n",
+       "      <td>1.2744</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>9</th>\n",
+       "      <td>0.1897</td>\n",
+       "      <td>0.2122</td>\n",
+       "      <td>1.1191</td>\n",
+       "      <td>1.1188</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>10</th>\n",
+       "      <td>0.1047</td>\n",
+       "      <td>0.1320</td>\n",
+       "      <td>1.2622</td>\n",
+       "      <td>1.2625</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>11</th>\n",
+       "      <td>0.1205</td>\n",
+       "      <td>0.1359</td>\n",
+       "      <td>1.1258</td>\n",
+       "      <td>1.1255</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>12</th>\n",
+       "      <td>0.0067</td>\n",
+       "      <td>0.0070</td>\n",
+       "      <td>1.1659</td>\n",
+       "      <td>1.1662</td>\n",
+       "    </tr>\n",
+       "  </tbody>\n",
+       "</table>\n",
+       "</div>"
+      ],
+      "text/plain": [
+       "   x_offset         x_scale        \n",
+       "     target learned  target learned\n",
+       "0    0.1489  0.1564  1.0507  1.0506\n",
+       "1    0.2305  0.1901  1.0882  1.0870\n",
+       "2    0.0265  0.0551  1.1556  1.1558\n",
+       "3    0.0396  0.0473  1.2093  1.2091\n",
+       "4    0.0922  0.1140  1.2400  1.2399\n",
+       "5    0.1902  0.1990  1.0483  1.0483\n",
+       "6    0.1470  0.1598  1.0847  1.0847\n",
+       "7    0.2689  0.3230  1.2045  1.2045\n",
+       "8    0.1367  0.1748  1.2746  1.2744\n",
+       "9    0.1897  0.2122  1.1191  1.1188\n",
+       "10   0.1047  0.1320  1.2622  1.2625\n",
+       "11   0.1205  0.1359  1.1258  1.1255\n",
+       "12   0.0067  0.0070  1.1659  1.1662"
+      ]
+     },
+     "execution_count": 21,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "df_x"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 22,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/html": [
+       "<div>\n",
+       "<style scoped>\n",
+       "    .dataframe tbody tr th:only-of-type {\n",
+       "        vertical-align: middle;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe tbody tr th {\n",
+       "        vertical-align: top;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe thead tr th {\n",
+       "        text-align: left;\n",
+       "    }\n",
+       "</style>\n",
+       "<table border=\"1\" class=\"dataframe\">\n",
+       "  <thead>\n",
+       "    <tr>\n",
+       "      <th></th>\n",
+       "      <th colspan=\"2\" halign=\"left\">y_offset</th>\n",
+       "      <th colspan=\"2\" halign=\"left\">y_scale</th>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th></th>\n",
+       "      <th>target</th>\n",
+       "      <th>learned</th>\n",
+       "      <th>target</th>\n",
+       "      <th>learned</th>\n",
+       "    </tr>\n",
+       "  </thead>\n",
+       "  <tbody>\n",
+       "    <tr>\n",
+       "      <th>0</th>\n",
+       "      <td>0.2858</td>\n",
+       "      <td>0.2889</td>\n",
+       "      <td>1.0108</td>\n",
+       "      <td>1.0110</td>\n",
+       "    </tr>\n",
+       "  </tbody>\n",
+       "</table>\n",
+       "</div>"
+      ],
+      "text/plain": [
+       "  y_offset         y_scale        \n",
+       "    target learned  target learned\n",
+       "0   0.2858  0.2889  1.0108  1.0110"
+      ]
+     },
+     "execution_count": 22,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "df_y"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": []
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python [conda env:nnprior]",
+   "language": "python",
+   "name": "conda-env-nnprior-py"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.9.20"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 4
+}

--- a/lcls/nn_prior/utils.py
+++ b/lcls/nn_prior/utils.py
@@ -144,7 +144,7 @@ def load_model(
         input_order=input_variables,
         output_order=lume_model.output_names[0:2],
     )
-    return ObjectiveModel(lume_module)
+    return ObjectiveModel(lume_module, use_sim_model=use_sim_model)
 
 
 def get_model_predictions(


### PR DESCRIPTION
Adds an exemplary notebook comparing implicit calibration during a BO run to backpropagation.